### PR TITLE
fix(core): honor backgrounds on empty-content pseudo-elements

### DIFF
--- a/core/src/integration/color-contrast-enhanced.browser.test.ts
+++ b/core/src/integration/color-contrast-enhanced.browser.test.ts
@@ -104,3 +104,26 @@ describe("stylesheet-applied colors at AAA", () => {
     expect(run()).toHaveLength(0);
   });
 });
+
+describe("empty-content pseudo-element backgrounds", () => {
+  it("skips: empty-content ::before providing an ancestor background makes AAA contrast unreliable", () => {
+    setContent(`
+      <style>
+        body { background: #000 }
+        .promo { position: relative; color: #000 }
+        .promo::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: #fafafa;
+          z-index: 0;
+        }
+        .content { position: relative; z-index: 1 }
+      </style>
+      <div class="promo">
+        <div class="content"><span>Text over an empty-content pseudo background</span></div>
+      </div>
+    `);
+    expect(run()).toHaveLength(0);
+  });
+});

--- a/core/src/integration/color-contrast.browser.test.ts
+++ b/core/src/integration/color-contrast.browser.test.ts
@@ -178,6 +178,41 @@ describe("visual edge cases", () => {
     expect(violations[0].context).toMatch(/required: 4\.5:1/);
   });
 
+  it("skips: empty-content ::before providing an ancestor background makes contrast unreliable", () => {
+    setContent(`
+      <style>
+        body { background: #000 }
+        .promo { position: relative; color: #000 }
+        .promo::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: #fafafa;
+          z-index: 0;
+        }
+        .content { position: relative; z-index: 1 }
+      </style>
+      <div class="promo">
+        <div class="content"><span>Text over an empty-content pseudo background</span></div>
+      </div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("does not skip: empty-content ::before without a visual background", () => {
+    setContent(`
+      <style>
+        body { background: #000 }
+        .plain { color: #000 }
+        .plain::before { content: "" }
+      </style>
+      <div class="plain">Genuine low contrast</div>
+    `);
+    const violations = run();
+    expectViolation(violations);
+    expect(violations[0].context).toMatch(/ratio: 1:1/);
+  });
+
   it("skips: ::before pseudo-element providing background overlay makes contrast unreliable", () => {
     setContent(`
       <style>

--- a/core/src/rules/utils/color.ts
+++ b/core/src/rules/utils/color.ts
@@ -436,8 +436,9 @@ export function hasPseudoElementBackground(el: Element): boolean {
         const win = getWindow(current);
         const ps = win ? win.getComputedStyle(current, pseudo) : getComputedStyle(current, pseudo);
         const content = ps.content;
-        // No pseudo-element if content is none/normal/empty
-        if (!content || content === "none" || content === "normal" || content === '""') continue;
+        // No pseudo-element if generated content is absent.
+        // An empty string can still render a visual background.
+        if (!content || content === "none" || content === "normal") continue;
         // Check for non-transparent background color
         const bgColor = ps.backgroundColor;
         if (bgColor && !isTransparent(bgColor) && parseColorAlpha(bgColor) >= 0.1) return true;


### PR DESCRIPTION
Hi, I caught a false positive on the contrast checks while checking https://www.404media.co/

Version 0.13.0 of AccessLint Core reports a contrast issue on this paragraph when it shouldn't:

<img width="971" height="456" alt="Screenshot 2026-07-18 at 10 16 25" src="https://github.com/user-attachments/assets/984268a7-c509-4cd2-8b5e-eff665a7c797" />

```json
{
          "ruleId": "distinguishable/color-contrast",
          "selector": "main > div:nth-of-type(2) > div > div > span:nth-of-type(1)",
          "html": "<span>404 Media is an independent media company founded by technology journalists Jason Koebler, Emanuel Maiberg, Samantha Cole, and Joseph Cox.</span>",
          "impact": "serious",
          "message": "Insufficient color contrast ratio of 1:1 (required 4.5:1).",
          "context": "foreground: #000000 rgb(0, 0, 0), background: #000000 rgb(0, 0, 0), ratio: 1:1, required: 4.5:1",
          "fix": {
            "type": "suggest",
            "suggestion": "Change the text color or background color so the contrast ratio meets 4.5:1. Current foreground is #000000, background is #000000."
          }
        }
```

So I asked Codex to fix that; here's the rationale:

> Pseudo-elements can paint a visual background with content: "". The contrast helper treated those pseudo-elements as absent, then used the underlying ancestor or body color and produced false 1:1 failures, as seen on 404 Media.
>
>Let the existing background, image, and geometry checks inspect empty-content pseudo-elements so AA and AAA skip calculations when the effective background is unreliable. Add real-browser regressions for both rules plus a control proving non-visual empty pseudo-elements still report genuine low contrast.

I've checked that URL with that fix, and now it works fine.