### PR TITLE
Include engine and environment metadata in audit results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 results/
 .env
 .turbo/
+.worktrees/

--- a/cli/src/cdp-audit.test.ts
+++ b/cli/src/cdp-audit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildAuditExpression } from "./cdp-audit.js";
+
+describe("buildAuditExpression", () => {
+  it("preserves test engine and environment metadata across JSON serialization", async () => {
+    const testEngine = { name: "accesslint", version: "0.14.1" };
+    const testEnvironment = {
+      userAgent: "Test Browser",
+      windowWidth: 800,
+      windowHeight: 600,
+      orientationAngle: 0,
+      orientationType: "portrait-primary",
+    };
+    const windowStub = {
+      AccessLint: {
+        runAudit: () => ({
+          url: "https://example.com/",
+          timestamp: 123,
+          testEngine,
+          testEnvironment,
+          ruleCount: 94,
+          skippedRules: [],
+          violations: [],
+        }),
+      },
+    };
+    const documentStub = {};
+    const expression = buildAuditExpression("", {});
+    const evaluate = new Function(
+      "window",
+      "document",
+      "expression",
+      "return eval(expression);",
+    ) as (window: unknown, document: unknown, expression: string) => Promise<string>;
+
+    const parsed = JSON.parse(await evaluate(windowStub, documentStub, expression));
+
+    expect(parsed.testEngine).toEqual(testEngine);
+    expect(parsed.testEnvironment).toEqual(testEnvironment);
+  });
+});

--- a/cli/src/cdp-audit.ts
+++ b/cli/src/cdp-audit.ts
@@ -1,4 +1,4 @@
-import type { Violation } from "@accesslint/core";
+import type { TestEngine, TestEnvironment, Violation } from "@accesslint/core";
 import { isFingerprintableTag, normalizeHtml, sha1Short } from "@accesslint/heal-diff/normalize";
 import type { SnapshotViolation } from "@accesslint/matchers-internal/snapshot";
 
@@ -49,6 +49,8 @@ export function buildAuditExpression(
       ok: true,
       url: __r.url,
       timestamp: __r.timestamp,
+      testEngine: __r.testEngine,
+      testEnvironment: __r.testEnvironment,
       ruleCount: __r.ruleCount,
       skippedRules: __r.skippedRules || [],
       violations: __violations.map(function (v) {
@@ -102,6 +104,8 @@ export interface InPageOk {
   ok: true;
   url: string;
   timestamp: number;
+  testEngine: TestEngine;
+  testEnvironment: TestEnvironment;
   ruleCount: number;
   skippedRules: { ruleId: string; error: string }[];
   violations: InPageViolation[];

--- a/cli/src/cdp.ts
+++ b/cli/src/cdp.ts
@@ -259,6 +259,8 @@ export async function runLiveAudit(opts: RunLiveAuditOptions): Promise<RunLiveAu
       result: {
         url: parsed.url,
         timestamp: parsed.timestamp,
+        testEngine: parsed.testEngine,
+        testEnvironment: parsed.testEnvironment,
         ruleCount: parsed.ruleCount,
         skippedRules: parsed.skippedRules,
         violations: parsed.violations as unknown as Violation[],

--- a/core/README.md
+++ b/core/README.md
@@ -129,8 +129,24 @@ interface AuditOptions {
 interface AuditResult {
   url: string;
   timestamp: number;
+  testEngine: TestEngine;
+  testEnvironment: TestEnvironment;
   violations: Violation[];
   ruleCount: number;
+  skippedRules: { ruleId: string; error: string }[];
+}
+
+interface TestEngine {
+  name: "accesslint";
+  version: string;
+}
+
+interface TestEnvironment {
+  userAgent: string;
+  windowWidth: number;
+  windowHeight: number;
+  orientationAngle: number;
+  orientationType: string;
 }
 
 interface Violation {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -18,6 +18,8 @@ export type {
   Rule,
   Violation,
   AuditResult,
+  TestEngine,
+  TestEnvironment,
   DiffResult,
   Fixability,
   FixSuggestion,

--- a/core/src/metadata.test.ts
+++ b/core/src/metadata.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import packageJson from "../package.json";
+import { getTestMetadata } from "./metadata";
+
+const fallbackEnvironment = {
+  userAgent: "",
+  windowWidth: 0,
+  windowHeight: 0,
+  orientationAngle: 0,
+  orientationType: "portrait-primary",
+};
+
+describe("getTestMetadata", () => {
+  it("uses stable defaults when the document has no window", () => {
+    const result = getTestMetadata({ defaultView: null } as Document);
+
+    expect(result).toEqual({
+      testEngine: { name: "accesslint", version: packageJson.version },
+      testEnvironment: fallbackEnvironment,
+    });
+  });
+
+  it("isolates throwing host getters and preserves readable values", () => {
+    const view = {
+      get navigator() {
+        throw new Error("navigator unavailable");
+      },
+      innerWidth: 800,
+      innerHeight: 600,
+      screen: {
+        orientation: { angle: 90, type: "landscape-primary" },
+      },
+    };
+
+    const result = getTestMetadata({ defaultView: view } as unknown as Document);
+
+    expect(result.testEnvironment).toEqual({
+      userAgent: "",
+      windowWidth: 800,
+      windowHeight: 600,
+      orientationAngle: 90,
+      orientationType: "landscape-primary",
+    });
+  });
+
+  it("falls back for throwing document access and invalid host values", () => {
+    const inaccessibleDocument = {
+      get defaultView() {
+        throw new Error("window unavailable");
+      },
+    };
+    const malformedDocument = {
+      defaultView: {
+        navigator: { userAgent: 123 },
+        innerWidth: Number.NaN,
+        innerHeight: 600,
+        screen: { orientation: { angle: Number.POSITIVE_INFINITY, type: null } },
+      },
+    };
+
+    expect(getTestMetadata(inaccessibleDocument as unknown as Document).testEnvironment).toEqual(
+      fallbackEnvironment,
+    );
+    expect(getTestMetadata(malformedDocument as unknown as Document).testEnvironment).toEqual({
+      ...fallbackEnvironment,
+      windowHeight: 600,
+    });
+  });
+});

--- a/core/src/metadata.ts
+++ b/core/src/metadata.ts
@@ -1,0 +1,40 @@
+import packageJson from "../package.json";
+import type { TestEngine, TestEnvironment } from "./rules/types";
+
+export interface TestMetadata {
+  testEngine: TestEngine;
+  testEnvironment: TestEnvironment;
+}
+
+function read<T>(getter: () => T, fallback: T): T {
+  try {
+    return getter();
+  } catch {
+    return fallback;
+  }
+}
+
+function readString(getter: () => unknown, fallback: string): string {
+  const value = read(getter, fallback);
+  return typeof value === "string" ? value : fallback;
+}
+
+function readFiniteNumber(getter: () => unknown): number {
+  const value = read(getter, 0);
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function getTestMetadata(doc: Document): TestMetadata {
+  const view = read(() => doc.defaultView, null);
+
+  return {
+    testEngine: { name: "accesslint", version: packageJson.version },
+    testEnvironment: {
+      userAgent: readString(() => view?.navigator?.userAgent, ""),
+      windowWidth: readFiniteNumber(() => view?.innerWidth),
+      windowHeight: readFiniteNumber(() => view?.innerHeight),
+      orientationAngle: readFiniteNumber(() => view?.screen?.orientation?.angle),
+      orientationType: readString(() => view?.screen?.orientation?.type, "portrait-primary"),
+    },
+  };
+}

--- a/core/src/rules/audit.test.ts
+++ b/core/src/rules/audit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { makeDoc } from "../test-helpers";
 import { runAudit, diffAudit, getActiveRules, createChunkedAudit } from "./index";
 import { generateDoc, SMALL_SIZE } from "../bench/fixtures";
+import packageJson from "../../package.json";
 
 describe("runAudit integration", () => {
   it("returns violations on a realistic document", () => {
@@ -33,6 +34,24 @@ describe("runAudit integration", () => {
     );
     const result = runAudit(doc);
     expect(result.violations).toHaveLength(0);
+  });
+
+  it("reports the test engine and audited document environment", () => {
+    const doc = makeDoc(
+      '<html lang="en"><head><title>Metadata</title></head><body><main><h1>Hello</h1></main></body></html>',
+    );
+
+    const result = runAudit(doc);
+    const view = doc.defaultView!;
+
+    expect(result.testEngine).toEqual({ name: "accesslint", version: packageJson.version });
+    expect(result.testEnvironment).toEqual({
+      userAgent: view.navigator.userAgent,
+      windowWidth: view.innerWidth,
+      windowHeight: view.innerHeight,
+      orientationAngle: view.screen.orientation?.angle ?? 0,
+      orientationType: view.screen.orientation?.type ?? "portrait-primary",
+    });
   });
 
   it("is deterministic across runs", () => {
@@ -204,7 +223,21 @@ describe("diffAudit", () => {
   });
 
   it("handles empty results", () => {
-    const empty = { url: "", timestamp: 0, violations: [], ruleCount: 0, skippedRules: [] };
+    const empty = {
+      url: "",
+      timestamp: 0,
+      testEngine: { name: "accesslint" as const, version: packageJson.version },
+      testEnvironment: {
+        userAgent: "",
+        windowWidth: 0,
+        windowHeight: 0,
+        orientationAngle: 0,
+        orientationType: "portrait-primary",
+      },
+      violations: [],
+      ruleCount: 0,
+      skippedRules: [],
+    };
     const diff = diffAudit(empty, empty);
     expect(diff.added).toHaveLength(0);
     expect(diff.fixed).toHaveLength(0);

--- a/core/src/rules/index.ts
+++ b/core/src/rules/index.ts
@@ -1,4 +1,5 @@
 import type { Rule, Violation, AuditResult, DiffResult } from "./types";
+import { getTestMetadata } from "../metadata";
 import {
   clearAriaHiddenCache,
   clearComputedRoleCache,
@@ -381,9 +382,12 @@ export function runAudit(doc: Document, options?: AuditOptions): AuditResult {
     }
   }
   backfillElements(violations, doc);
+  const { testEngine, testEnvironment } = getTestMetadata(doc);
   return {
     url: doc.location?.href ?? "",
     timestamp: Date.now(),
+    testEngine,
+    testEnvironment,
     violations: locale ? translateViolations(violations, locale) : violations,
     ruleCount: activeRules.length,
     skippedRules,

--- a/core/src/rules/types.ts
+++ b/core/src/rules/types.ts
@@ -78,9 +78,24 @@ export interface SourceLocation {
   ownerDepth: number;
 }
 
+export interface TestEngine {
+  name: "accesslint";
+  version: string;
+}
+
+export interface TestEnvironment {
+  userAgent: string;
+  windowWidth: number;
+  windowHeight: number;
+  orientationAngle: number;
+  orientationType: string;
+}
+
 export interface AuditResult {
   url: string;
   timestamp: number;
+  testEngine: TestEngine;
+  testEnvironment: TestEnvironment;
   violations: Violation[];
   ruleCount: number;
   skippedRules: { ruleId: string; error: string }[];

--- a/core/src/standalone.ts
+++ b/core/src/standalone.ts
@@ -13,6 +13,8 @@ export type {
   Rule,
   Violation,
   AuditResult,
+  TestEngine,
+  TestEnvironment,
   DeclarativeRule,
   CheckType,
   SourceLocation,

--- a/matchers-internal/src/matchers.test.ts
+++ b/matchers-internal/src/matchers.test.ts
@@ -23,7 +23,21 @@ const mockRunAudit = vi.mocked(runAudit);
 const mockGetRuleById = vi.mocked(getRuleById);
 
 function auditResult(violations: Violation[]): AuditResult {
-  return { url: "about:blank", timestamp: 0, violations, ruleCount: 1, skippedRules: [] };
+  return {
+    url: "about:blank",
+    timestamp: 0,
+    testEngine: { name: "accesslint", version: "0.14.1" },
+    testEnvironment: {
+      userAgent: "",
+      windowWidth: 0,
+      windowHeight: 0,
+      orientationAngle: 0,
+      orientationType: "portrait-primary",
+    },
+    violations,
+    ruleCount: 1,
+    skippedRules: [],
+  };
 }
 
 function violation(overrides: Partial<Violation> = {}): Violation {


### PR DESCRIPTION
Hi, I thought it would be useful to include the AccessLint version and test version in the results. This simplifies integrations, for example when you're saving the results it's useful to know the exact version and environment.

## Summary

- add Axe-compatible `testEngine` and `testEnvironment` metadata to every Core `AuditResult`
- source the engine version from `@accesslint/core` and capture browser data from the audited document's realm with safe fallbacks
- preserve metadata through CLI CDP serialization and document the expanded public API

## Compatibility

This is additive for JSON consumers. The two metadata objects are required in the TypeScript `AuditResult` contract, so custom producers must include them.

## Test plan

- `bun run test` — 23 workspace tasks passed, including 971 Core tests and 61 Playwright tests
- `bun run typecheck` — 19 workspace tasks passed
- production ESM, CJS, and IIFE builds passed publint and Are the Types Wrong checks
- affected files passed Prettier and ESLint with zero errors
