### PR TITLE
Fix Windows path-separator bug in loadCoreIIFE (#4)

### DIFF
--- a/cli/src/iife-source.test.ts
+++ b/cli/src/iife-source.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { corePkgPath, loadCoreIIFE } from "./iife-source.js";
+
+describe("corePkgPath", () => {
+  it("derives package.json from a POSIX IIFE path", () => {
+    const iife = "/home/u/node_modules/@accesslint/core/dist/index.iife.js";
+    expect(corePkgPath(iife, path.posix)).toBe(
+      "/home/u/node_modules/@accesslint/core/package.json",
+    );
+  });
+
+  it("derives package.json from a Windows IIFE path (issue #4)", () => {
+    const iife = "C:\\app\\node_modules\\@accesslint\\core\\dist\\index.iife.js";
+    expect(corePkgPath(iife, path.win32)).toBe(
+      "C:\\app\\node_modules\\@accesslint\\core\\package.json",
+    );
+  });
+});
+
+describe("loadCoreIIFE", () => {
+  it("reads a valid version and non-empty bundle from the resolved core", () => {
+    const { bytes, version } = loadCoreIIFE();
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+});

--- a/cli/src/iife-source.ts
+++ b/cli/src/iife-source.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 
 const require = createRequire(import.meta.url);
 
@@ -9,11 +10,21 @@ interface CorePackage {
   version?: string;
 }
 
+/**
+ * Derive the path to @accesslint/core's package.json from the resolved IIFE
+ * path (`.../core/dist/index.iife.js`). Uses path.dirname twice so it works
+ * regardless of separator; `pathImpl` is injectable to exercise win32 paths
+ * on POSIX hosts.
+ */
+export function corePkgPath(iifePath: string, pathImpl: typeof path = path): string {
+  return pathImpl.join(pathImpl.dirname(pathImpl.dirname(iifePath)), "package.json");
+}
+
 export function loadCoreIIFE(): { bytes: string; version: string } {
   if (cached !== null) return cached;
   const iifePath = require.resolve("@accesslint/core/iife");
   const bytes = readFileSync(iifePath, "utf8");
-  const pkgPath = iifePath.replace(/\/dist\/[^/]+$/, "/package.json");
+  const pkgPath = corePkgPath(iifePath);
   const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as CorePackage;
   if (!pkg.version) {
     throw new Error(`@accesslint/core package.json at ${pkgPath} is missing 'version'`);


### PR DESCRIPTION
Fixes #4.

## Problem

On Windows, every `scan` failed with a misleading `CDP error: Unexpected token 'v', "var Access"... is not valid JSON`.

`loadCoreIIFE()` derived `@accesslint/core`'s `package.json` from the resolved IIFE path with a forward-slash-only regex:

```js
const pkgPath = iifePath.replace(/\/dist\/[^/]+$/, "/package.json");
```

`require.resolve` returns backslash-separated paths on Windows, so the regex never matched, `pkgPath` stayed pointed at the IIFE bundle, and `JSON.parse` of `var AccessLint=(…)` threw. The outer catch in `runLiveAudit` relabeled it as a `CDP error`.

## Fix

- Derive the path with `path.dirname`/`path.join` so it is separator-agnostic, extracted as a pure `corePkgPath(iifePath, pathImpl)` helper.
- Add `cli/src/iife-source.test.ts` with POSIX and win32 (backslash) cases — the win32 case is the direct regression guard — plus an integration check that `loadCoreIIFE()` reads a real version and bundle.

The `dist/*.js` occurrences noted in the issue are build output regenerated from this single source.

## Verification

All 56 CLI tests pass; build (attw + publint) clean.