### PR TITLE
Harden audit metadata contract and expose engine version

### DIFF
--- a/cli/src/cdp-audit.test.ts
+++ b/cli/src/cdp-audit.test.ts
@@ -38,4 +38,37 @@ describe("buildAuditExpression", () => {
     expect(parsed.testEngine).toEqual(testEngine);
     expect(parsed.testEnvironment).toEqual(testEnvironment);
   });
+
+  it("backfills metadata when the injected engine predates the contract", async () => {
+    const windowStub = {
+      AccessLint: {
+        runAudit: () => ({
+          url: "https://example.com/",
+          timestamp: 123,
+          ruleCount: 94,
+          skippedRules: [],
+          violations: [],
+        }),
+      },
+    };
+    const documentStub = {};
+    const expression = buildAuditExpression("", {}, undefined, "0.15.0");
+    const evaluate = new Function(
+      "window",
+      "document",
+      "expression",
+      "return eval(expression);",
+    ) as (window: unknown, document: unknown, expression: string) => Promise<string>;
+
+    const parsed = JSON.parse(await evaluate(windowStub, documentStub, expression));
+
+    expect(parsed.testEngine).toEqual({ name: "accesslint", version: "0.15.0" });
+    expect(parsed.testEnvironment).toEqual({
+      userAgent: "",
+      windowWidth: 0,
+      windowHeight: 0,
+      orientationAngle: 0,
+      orientationType: "portrait-primary",
+    });
+  });
 });

--- a/cli/src/cdp-audit.ts
+++ b/cli/src/cdp-audit.ts
@@ -11,16 +11,27 @@ export interface CoreAuditExprOptions {
 }
 
 /**
+ * Sentinel environment matching core's getTestMetadata fallbacks, for engines
+ * older than the testEngine/testEnvironment contract.
+ */
+const FALLBACK_ENVIRONMENT_JS = `{ userAgent: "", windowWidth: 0, windowHeight: 0, orientationAngle: 0, orientationType: "portrait-primary" }`;
+
+/**
  * Build the in-page expression that injects @accesslint/core and runs an audit.
  * Used by the CLI's single-shot live audit to produce stable violation identities.
+ *
+ * `engineVersion` is the version of the resolved IIFE (from loadCoreIIFE),
+ * used to backfill `testEngine` when the injected engine predates it.
  */
 export function buildAuditExpression(
   iifeBytes: string,
   coreOptions: CoreAuditExprOptions,
   selector?: string,
+  engineVersion = "unknown",
 ): string {
   const optsJson = JSON.stringify(coreOptions);
   const selectorJson = selector ? JSON.stringify(selector) : "null";
+  const engineJson = JSON.stringify({ name: "accesslint", version: engineVersion });
   return `${iifeBytes}
 ;(async () => {
   try {
@@ -49,8 +60,8 @@ export function buildAuditExpression(
       ok: true,
       url: __r.url,
       timestamp: __r.timestamp,
-      testEngine: __r.testEngine,
-      testEnvironment: __r.testEnvironment,
+      testEngine: __r.testEngine || ${engineJson},
+      testEnvironment: __r.testEnvironment || ${FALLBACK_ENVIRONMENT_JS},
       ruleCount: __r.ruleCount,
       skippedRules: __r.skippedRules || [],
       violations: __violations.map(function (v) {

--- a/cli/src/cdp.ts
+++ b/cli/src/cdp.ts
@@ -216,8 +216,8 @@ export async function runLiveAudit(opts: RunLiveAuditOptions): Promise<RunLiveAu
       await waitForSelector(client, opts.selector, opts.waitTimeoutMs ?? WAIT_FOR_DEFAULT_MS);
     }
 
-    const { bytes } = loadCoreIIFE();
-    const expression = buildAuditExpression(bytes, opts.coreOptions, opts.selector);
+    const { bytes, version } = loadCoreIIFE();
+    const expression = buildAuditExpression(bytes, opts.coreOptions, opts.selector, version);
 
     const evalResult = await client.Runtime.evaluate({
       expression,

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -5,6 +5,7 @@ import { resolveInput } from "./input.js";
 import { isHTMLFragment } from "./html-util.js";
 import { format } from "./format.js";
 import { runLiveAudit } from "./cdp.js";
+import { coreEngineVersion } from "./iife-source.js";
 import {
   evaluateSnapshot,
   isUpdateMode,
@@ -243,7 +244,7 @@ function formatSnapshotResult(snap: SnapshotResult, name: string): string {
 const main = defineCommand({
   meta: {
     name: "accesslint",
-    version,
+    version: `${version} (engine ${coreEngineVersion()})`,
     description: "Audit HTML for accessibility violations",
   },
   subCommands: {

--- a/cli/src/iife-source.ts
+++ b/cli/src/iife-source.ts
@@ -20,6 +20,21 @@ export function corePkgPath(iifePath: string, pathImpl: typeof path = path): str
   return pathImpl.join(pathImpl.dirname(pathImpl.dirname(iifePath)), "package.json");
 }
 
+/**
+ * Version of the resolved @accesslint/core engine, without reading the IIFE
+ * bytes. Returns "unknown" when core cannot be resolved (a broken install).
+ */
+export function coreEngineVersion(): string {
+  if (cached !== null) return cached.version;
+  try {
+    const iifePath = require.resolve("@accesslint/core/iife");
+    const pkg = JSON.parse(readFileSync(corePkgPath(iifePath), "utf8")) as CorePackage;
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
 export function loadCoreIIFE(): { bytes: string; version: string } {
   if (cached !== null) return cached;
   const iifePath = require.resolve("@accesslint/core/iife");

--- a/core/README.md
+++ b/core/README.md
@@ -148,7 +148,11 @@ interface TestEnvironment {
   orientationAngle: number;
   orientationType: string;
 }
+```
 
+`testEngine.version` is the `@accesslint/core` engine version. `testEnvironment` describes the audited document's realm; unreadable values fall back to `""`, `0`, and `"portrait-primary"`.
+
+```ts
 interface Violation {
   ruleId: string;
   selector: string;
@@ -170,6 +174,14 @@ interface SourceLocation {
   /** 0 = JSX literal that produced the element; 1+ = enclosing component(s). */
   ownerDepth: number;
 }
+```
+
+### `version: string`
+
+The engine version, mirroring `axe.version`. Also available as `AccessLint.version` on the standalone (IIFE) global.
+
+```ts
+import { version } from "@accesslint/core";
 ```
 
 ### `createChunkedAudit(doc: Document, options?: AuditOptions): ChunkedAudit`

--- a/core/src/act/browser-earl-reporter.ts
+++ b/core/src/act/browser-earl-reporter.ts
@@ -6,16 +6,15 @@ import type {
   TestCase,
   TestResult,
 } from "@playwright/test/reporter";
-import { writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { generateEarlReport, isCorrectOutcome, type FixtureOutcome } from "./earl-report";
+import { version } from "../metadata";
 
 const EARL_OUTPUT_PATH = resolve(
   import.meta.dirname,
   "../../act-fixtures/earl-report-browser.json",
 );
-
-const PACKAGE_JSON_PATH = resolve(import.meta.dirname, "../../package.json");
 
 /**
  * Playwright reporter that generates a W3C EARL report from browser ACT tests.
@@ -105,9 +104,7 @@ export default class BrowserEarlReporter implements Reporter {
   onEnd(_result: FullResult): void {
     if (this.outcomes.length === 0) return;
 
-    const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf-8"));
-
-    const report = generateEarlReport(this.outcomes, pkg.version);
+    const report = generateEarlReport(this.outcomes, version);
     const outputDir = dirname(EARL_OUTPUT_PATH);
     mkdirSync(outputDir, { recursive: true });
     writeFileSync(EARL_OUTPUT_PATH, JSON.stringify(report, null, 2) + "\n");

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,3 +1,5 @@
+export { version } from "./metadata";
+
 // Core audit
 export {
   rules,

--- a/core/src/metadata.test.ts
+++ b/core/src/metadata.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import packageJson from "../package.json";
-import { getTestMetadata } from "./metadata";
+import { getTestMetadata, version } from "./metadata";
+
+describe("version", () => {
+  it("exposes the engine version", () => {
+    expect(version).toBe(packageJson.version);
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
 
 const fallbackEnvironment = {
   userAgent: "",

--- a/core/src/metadata.ts
+++ b/core/src/metadata.ts
@@ -1,6 +1,9 @@
 import packageJson from "../package.json";
 import type { TestEngine, TestEnvironment } from "./rules/types";
 
+/** The @accesslint/core engine version, mirroring `axe.version`. */
+export const version: string = packageJson.version;
+
 export interface TestMetadata {
   testEngine: TestEngine;
   testEnvironment: TestEnvironment;

--- a/core/src/metadata.ts
+++ b/core/src/metadata.ts
@@ -1,4 +1,4 @@
-import packageJson from "../package.json";
+import packageJson from "../package.json" with { type: "json" };
 import type { TestEngine, TestEnvironment } from "./rules/types";
 
 /** The @accesslint/core engine version, mirroring `axe.version`. */

--- a/core/src/standalone.ts
+++ b/core/src/standalone.ts
@@ -1,5 +1,7 @@
 // Standalone (IIFE) entry point — excludes locale data bundles.
 
+export { version } from "./metadata";
+
 // Core audit
 export { rules, runAudit, getRuleById, getActiveRules, clearAllCaches } from "./rules/index";
 export type { ChunkedAudit, AuditOptions } from "./rules/index";

--- a/playwright/src/audit.test.ts
+++ b/playwright/src/audit.test.ts
@@ -128,6 +128,21 @@ test.describe("accesslintAudit", () => {
     expect(result.ruleCount).toBeGreaterThan(0);
   });
 
+  test("carries engine and environment metadata across the page boundary", async ({ page }) => {
+    await page.setContent(ACCESSIBLE_HTML);
+    const result = await accesslintAudit(page);
+    expect(result.testEngine.name).toBe("accesslint");
+    expect(result.testEngine.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(result.testEnvironment.userAgent).not.toBe("");
+    expect(result.testEnvironment.windowWidth).toBeGreaterThan(0);
+    expect(result.testEnvironment.windowHeight).toBeGreaterThan(0);
+    expect(result.skippedRules).toEqual([]);
+
+    const scoped = await accesslintAudit(page.locator("main"));
+    expect(scoped.testEngine).toEqual(result.testEngine);
+    expect(scoped.testEnvironment.userAgent).toBe(result.testEnvironment.userAgent);
+  });
+
   test("inaccessible page has violations", async ({ page }) => {
     await page.setContent(INACCESSIBLE_HTML);
     const result = await accesslintAudit(page);

--- a/playwright/src/audit.ts
+++ b/playwright/src/audit.ts
@@ -11,7 +11,8 @@ import {
   type BaseAccessibleMatcherOptions,
   type Impact,
 } from "@accesslint/matchers-internal/audit";
-import type { Violation } from "@accesslint/core";
+import { version as coreVersion } from "@accesslint/core";
+import type { TestEngine, TestEnvironment, Violation } from "@accesslint/core";
 
 const require = createRequire(import.meta.url);
 const iifePath = require.resolve("@accesslint/core/iife");
@@ -47,8 +48,33 @@ export interface AuditViolation {
 export interface AuditResult {
   url: string;
   timestamp: number;
+  testEngine: TestEngine;
+  testEnvironment: TestEnvironment;
   violations: AuditViolation[];
   ruleCount: number;
+  skippedRules: { ruleId: string; error: string }[];
+}
+
+/**
+ * Raw result crossing the page boundary. Metadata fields are absent when the
+ * page carries a pre-injected engine older than the metadata contract.
+ */
+type RawAuditResult = Omit<AuditResult, "testEngine" | "testEnvironment" | "skippedRules"> &
+  Partial<Pick<AuditResult, "testEngine" | "testEnvironment" | "skippedRules">>;
+
+function normalizeResult(raw: RawAuditResult): AuditResult {
+  return {
+    ...raw,
+    testEngine: raw.testEngine ?? { name: "accesslint", version: coreVersion },
+    testEnvironment: raw.testEnvironment ?? {
+      userAgent: "",
+      windowWidth: 0,
+      windowHeight: 0,
+      orientationAngle: 0,
+      orientationType: "portrait-primary",
+    },
+    skippedRules: raw.skippedRules ?? [],
+  };
 }
 
 function isPage(target: Page | Locator): target is Page {
@@ -209,13 +235,16 @@ export async function accesslintAudit(
   let result: AuditResult;
 
   if (isPage(target)) {
-    result = await page.evaluate((opts) => {
+    const rawResult: RawAuditResult = await page.evaluate((opts) => {
       const { runAudit } = (window as any).AccessLint;
       const raw = runAudit(document, opts);
       return {
         url: raw.url,
         timestamp: raw.timestamp,
+        testEngine: raw.testEngine,
+        testEnvironment: raw.testEnvironment,
         ruleCount: raw.ruleCount,
+        skippedRules: raw.skippedRules,
         violations: raw.violations.map((v: any) => ({
           ruleId: v.ruleId,
           selector: v.selector,
@@ -225,6 +254,7 @@ export async function accesslintAudit(
         })),
       };
     }, coreOpts);
+    result = normalizeResult(rawResult);
 
     if (options?.includeShadowDom !== false) {
       const shadowViolations = await auditShadowDom(page, coreOpts);
@@ -240,7 +270,7 @@ export async function accesslintAudit(
       result.violations.push(...frameViolations);
     }
   } else {
-    result = await target.evaluate((el, opts) => {
+    const rawResult: RawAuditResult = await target.evaluate((el, opts) => {
       const { runAudit } = (window as any).AccessLint;
       const raw = runAudit(document, opts);
       const scoped = raw.violations.filter((v: any) => {
@@ -254,7 +284,10 @@ export async function accesslintAudit(
       return {
         url: raw.url,
         timestamp: raw.timestamp,
+        testEngine: raw.testEngine,
+        testEnvironment: raw.testEnvironment,
         ruleCount: raw.ruleCount,
+        skippedRules: raw.skippedRules,
         violations: scoped.map((v: any) => ({
           ruleId: v.ruleId,
           selector: v.selector,
@@ -264,6 +297,7 @@ export async function accesslintAudit(
         })),
       };
     }, coreOpts);
+    result = normalizeResult(rawResult);
   }
 
   result.violations = applyFailOnFilter(result.violations, options?.failOn);

--- a/playwright/src/snapshot.test.ts
+++ b/playwright/src/snapshot.test.ts
@@ -133,8 +133,8 @@ test.describe("loadSnapshot / saveSnapshot", () => {
     const loaded = loadSnapshot(path);
 
     expect(loaded).toEqual([
-      { ruleId: "text-alternatives/img-alt", selector: "html > body > main > img" },
       { ruleId: "readable/html-has-lang", selector: "html" },
+      { ruleId: "text-alternatives/img-alt", selector: "html > body > main > img" },
     ]);
 
     rmSync(dir, { recursive: true });
@@ -280,7 +280,9 @@ test.describe("evaluateSnapshot", () => {
     const dir = createTempDir();
     const path = join(dir, "new.json");
 
-    saveSnapshot(path, [{ ruleId: "text-alternatives/img-alt", selector: "html > body > main > img" }]);
+    saveSnapshot(path, [
+      { ruleId: "text-alternatives/img-alt", selector: "html > body > main > img" },
+    ]);
 
     const result = evaluateSnapshot(
       [
@@ -323,11 +325,17 @@ test.describe("evaluateSnapshot", () => {
     const dir = createTempDir();
     const path = join(dir, "force.json");
 
-    saveSnapshot(path, [{ ruleId: "text-alternatives/img-alt", selector: "html > body > main > img" }]);
+    saveSnapshot(path, [
+      { ruleId: "text-alternatives/img-alt", selector: "html > body > main > img" },
+    ]);
 
-    const result = evaluateSnapshot([{ ruleId: "readable/html-has-lang", selector: "html" }], path, {
-      update: true,
-    });
+    const result = evaluateSnapshot(
+      [{ ruleId: "readable/html-has-lang", selector: "html" }],
+      path,
+      {
+        update: true,
+      },
+    );
 
     expect(result.pass).toBe(true);
     expect(result.updated).toBe(true);


### PR DESCRIPTION
Follow-ups to #5, which added Axe-compatible `testEngine` and `testEnvironment` to `AuditResult`. That PR guaranteed the fields from core's `runAudit`, but two consumer paths could still produce results without them, and the engine version was only reachable by running an audit.

## Summary

- **playwright**: `accesslintAudit` now forwards `testEngine`, `testEnvironment`, and `skippedRules` across the `page.evaluate` boundary (Page and Locator modes). Previously the hand-picked mapping dropped them, so Playwright results silently lacked the metadata that core/CLI results carry. Results are normalized with an engine-version fallback for pages carrying a pre-injected older engine.
- **cli**: the injected CDP audit expression backfills `testEngine` from the resolved `@accesslint/core` package version (which `loadCoreIIFE` already returned but `runLiveAudit` discarded) and falls back to core's sentinel `testEnvironment`, so the required fields survive a stale core `dist` during development instead of serializing to `undefined`.
- **core**: new `version` export (`axe.version` parity) from the ESM/CJS entry and as `AccessLint.version` on the IIFE global. The browser EARL reporter reuses it instead of reading `package.json` off disk.
- **cli**: `--version` now prints both versions, e.g. `0.11.1 (engine 0.14.1)`, since the CLI and engine version independently and `testEngine.version` refers to the engine.

Also includes a one-line fix for the `saveSnapshot` round-trip test, which has been failing on main since the rule ID rename (12b1b83) changed the alphabetical sort order of the expected violations.

## Verification

- `bun run test`: 23 workspace tasks pass, including 62 Playwright tests (one new: metadata across the page boundary in both Page and Locator modes)
- `bun run typecheck`: 19 tasks pass
- Built bundles verified by hand: `AccessLint.version` present on the IIFE global, `version` importable from ESM; probed `dist` for `devDependencies`/`publishConfig`/script names to confirm the `package.json` import still tree-shakes to the version string alone
- Live end-to-end: `accesslint scan --format json` against headless Chrome returns real `testEngine`/`testEnvironment` values; `accesslint --version` prints `0.11.1 (engine 0.14.1)`
- The 3 pre-existing ESLint errors on main are untouched; changed files lint clean and pass Prettier