### PR TITLE
fix(heal-diff): pair refusal memory, closing the data-testid silent false heal

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -9,6 +9,7 @@ import { coreEngineVersion } from "./iife-source.js";
 import {
   evaluateSnapshot,
   isUpdateMode,
+  refusedHealLines,
   resolveSnapshotPath,
   validateSnapshotName,
 } from "@accesslint/matchers-internal/snapshot";
@@ -203,13 +204,19 @@ function formatSnapshotResult(snap: SnapshotResult, name: string): string {
     const lines = [
       `Expected no new violations beyond snapshot "${name}", but found ${snap.newViolations.length} new:`,
     ];
+    const updateHint = "re-run with --update-snapshot or ACCESSLINT_UPDATE=1";
     for (const v of snap.newViolations) {
       lines.push(`  ${v.ruleId}: ${v.selector}`);
+      const refused = snap.refused.find((r) => r.current.selector === v.selector);
+      if (refused) {
+        lines.push(...refusedHealLines(refused, { updateHint }));
+        continue;
+      }
       const hint = snap.likelyMoved.find((lm) => lm.current.selector === v.selector);
       if (hint) {
         lines.push(`    likely moved from: ${hint.candidate.selector}`);
         lines.push(`    matched on: ${hint.sharedSignals.join(", ")}`);
-        lines.push(`    if same: re-run with --update-snapshot or ACCESSLINT_UPDATE=1`);
+        lines.push(`    if same: ${updateHint}`);
         lines.push(`    if new: add a data-testid to disambiguate`);
       }
     }

--- a/heal-diff/docs/RFC-multi-signal-healing.md
+++ b/heal-diff/docs/RFC-multi-signal-healing.md
@@ -66,7 +66,9 @@ Refused pairs are excluded from this scan, in the engine rather than at each ren
 
 ### 5. Keep screenshots, not just hashes
 
-Playwright captures per-violation PNGs via `locator.screenshot()` with bounded concurrency (4 parallel) into `<baselineName>-screenshots/<ruleIdSlug>_<discriminator>.png`. Filenames follow the ecosystem convention (Playwright / jest-image-snapshot / Cypress): sibling directory, human-readable names, binary in git. Discriminator is the slugified anchor when present, else the first 8 hex of `htmlFingerprint`. Orphan PNGs are GC'd on save. The image is what makes the "likely moved" hint instantly decidable.
+Playwright captures per-violation PNGs via `locator.screenshot()` with bounded concurrency (4 parallel) into `<baselineName>-screenshots/<ruleIdSlug>_<anchorSlug>_<fp8>.png`. Filenames follow the ecosystem convention (Playwright / jest-image-snapshot / Cypress): sibling directory, human-readable names, binary in git. Orphan PNGs are GC'd on save. The image is what makes the "likely moved" hint and the refused-heal message instantly decidable.
+
+Names are content-addressed: the first 8 hex of `htmlFingerprint` is part of the name, not a fallback for a missing anchor. Discriminating on the anchor alone made an element's baseline and impostor images compute the same path, and since each run starts with a fresh in-use set, the second run overwrote the first — no baseline image was ever retained for an anchored element, which is exactly the case where the two images matter most.
 
 ### 6. Grouping collapses root causes
 

--- a/heal-diff/docs/RFC-multi-signal-healing.md
+++ b/heal-diff/docs/RFC-multi-signal-healing.md
@@ -50,9 +50,19 @@ Accesslint's tier list:
 
 When tiers 2–6 match, the baseline entry is replaced in memory with the current-run item's full signal set, a `"healed"` record is appended to `.history.ndjson` with `{ tier, ruleId, oldSelector, newSelector }`, and the failure message prints one line per heal. The test still passes. Every heal is visible; none is silent. Healing + ratchet can happen in the same run.
 
+#### Refusal is terminal for the pair
+
+T1 carries `verifiedBy: htmlFingerprint`: when both items have a fingerprint and the values disagree, the pair is refused and both items are released to the tiers below (refuse-and-release). Release alone is not enough. `data-testid` is both the `anchor` signal and — since it is Playwright's default `testIdAttribute` — the `selector`, so for any element carrying one the anchor tier keys on exactly the information T1 just rejected, and re-pairs the impostor unverified one tier later. That is a silent false heal on the most common anchor attribute in the wild.
+
+So a refusal is remembered for the run: **these two items are not the same element**, which stays true at every weaker tier, and no later tier may pair them. The alternatives were both worse. Sending a refused *item* straight to `new` breaks the swapped-elements case, where two elements are refused at T1 and must still heal to their true partners at T5 — the refusal is a fact about the pair, not about either item. Adding `verifiedBy` tier by tier is whack-a-mole that terminates only when every tier verifies, which is a global fingerprint gate: it would refuse the legitimate "anchored element moved *and* its markup churned" case, precisely what the anchor tier exists to survive.
+
+Refusal memory is keyed on object identity, not signal values — matching is count-based, so two items with identical signals are distinct items and value-keying would refuse both when only one was refused. The uniqueness gate keeps counting raw bucket length, refusals included, which preserves the invariant that **a refusal can only ever subtract a heal, never create one**. Pairs still unresolved at the end of the run surface as `DiffResult.refused` with the disagreeing signal name, and the matcher renders them in place of the "likely moved" hint (§4).
+
 ### 4. "Likely moved" as a diagnostic, not a match
 
 For violations that don't heal, a post-pass scans the unmatched sets and pairs any current with any baseline sharing two-or-more of `{tag, htmlFingerprint, relativeLocation}`. These are surfaced as `likelyMoved` metadata alongside the failure message, with the shared signal names and (where available) paths to baseline and current element screenshots. The developer reads one block and decides: same issue moved → `ACCESSLINT_UPDATE=1`; genuinely new → add a `data-testid`.
+
+Refused pairs are excluded from this scan, in the engine rather than at each render site. A refused pair typically shares `tag` and `relativeLocation`, so it clears the threshold and every line of the resulting hint is false: it claims the element moved from its own selector, and it coaches the developer to add a `data-testid` the element already has, or to run `ACCESSLINT_UPDATE=1` on markup the matcher just decided is a different element. Turning silent heals into failures is only worth it if the failure says something true.
 
 ### 5. Keep screenshots, not just hashes
 
@@ -101,6 +111,19 @@ Cheapest first. The risk we bound is *silent false heal* (accepting a real regre
 - **Screenshot PNGs in git** unless opted out. Matches ecosystem convention.
 - **Tier 6 can false-heal** under exotic duplicates. Mitigated by uniqueness-gating.
 - **Role and HTML fingerprint require live DOM access**. jsdom provides it; Playwright computes in-page via `AccessLint` IIFE globals.
+
+## Known limitation: an impostor that reuses a non-selector anchor
+
+Refusals originate at T1, so the hole closes only where the pair actually meets there. For `data-testid` that is always, since the selector *is* the test id. For an anchor the selector doesn't encode, it isn't:
+
+```
+baseline: getByRole('img').first()  anchor data-id=hero  fp aaa
+current:  getByRole('img').nth(1)   anchor data-id=hero  fp bbb   <- different element
+```
+
+The two never meet at T1, so nothing is refused and the anchor tier heals. Signal for signal this is identical to the legitimate "moved and its markup churned" case; no deterministic rule separates them, and gating anchor heals on fingerprint agreement would close it by gutting the tier.
+
+Held open pending data. Proposed investigation: instrument the anchor-heal path to record when it heals across a fingerprint disagreement, then measure frequency — either from real app git histories (audit commit N and N+1, compare captured signals) or by shipping it as a passing-run warning first and collecting real usage. Whether gating is affordable is a question about that frequency, not about the mechanism.
 
 ## Open questions
 

--- a/heal-diff/src/diff.test.ts
+++ b/heal-diff/src/diff.test.ts
@@ -219,6 +219,19 @@ describe("diff() — verifiedBy", () => {
     expect(result.matched).toHaveLength(1);
   });
 
+  it("swapped elements leave no unresolved refusal to report", () => {
+    const baseline = [
+      item("img-alt", { selector: "s1", htmlFingerprint: "f1" }),
+      item("img-alt", { selector: "s2", htmlFingerprint: "f2" }),
+    ];
+    const current = [
+      item("img-alt", { selector: "s2", htmlFingerprint: "f1" }),
+      item("img-alt", { selector: "s1", htmlFingerprint: "f2" }),
+    ];
+    const result = diff(baseline, current, [T1v, T5]);
+    expect(result.refused).toHaveLength(0);
+  });
+
   it("picks the verifying candidate among duplicates sharing the tier key", () => {
     const baseline = [
       item("img-alt", { selector: "body > img", htmlFingerprint: "aaa" }),
@@ -229,6 +242,118 @@ describe("diff() — verifiedBy", () => {
     expect(result.matched).toHaveLength(1);
     expect(result.matched[0].baseline.signals.htmlFingerprint).toBe("bbb");
     expect(result.fixed.map((i) => i.signals.htmlFingerprint)).toEqual(["aaa"]);
+  });
+});
+
+describe("diff() — refusal memory", () => {
+  const T1v = buildTier<Sig>({
+    name: "exact",
+    key: ["id", "selector"],
+    heal: false,
+    verifiedBy: "htmlFingerprint",
+  });
+
+  // A `data-testid` element is the worst case: its anchor is a strict function
+  // of its selector, so without refusal memory T1's verification buys nothing —
+  // the anchor tier re-pairs the same two items unverified one tier later.
+  it("does not re-match a pair the exact tier refused at the anchor tier", () => {
+    const baseline = [
+      item("img-alt", {
+        selector: "getByTestId('hero')",
+        anchor: "data-testid=hero",
+        htmlFingerprint: "aaa",
+      }),
+    ];
+    const current = [
+      item("img-alt", {
+        selector: "getByTestId('hero')",
+        anchor: "data-testid=hero",
+        htmlFingerprint: "bbb",
+      }),
+    ];
+    const result = diff(baseline, current, [T1v, T2]);
+    expect(result.healed).toHaveLength(0);
+    expect(result.new).toHaveLength(1);
+    expect(result.fixed).toHaveLength(1);
+    expect(result.refused).toHaveLength(1);
+    expect(result.refused[0].tier).toBe("exact");
+    expect(result.refused[0].signal).toBe("htmlFingerprint");
+    expect(result.refused[0].baseline.signals.htmlFingerprint).toBe("aaa");
+    expect(result.refused[0].current.signals.htmlFingerprint).toBe("bbb");
+  });
+
+  it("still heals on the anchor when the pair never met at the exact tier", () => {
+    const baseline = [
+      item("img-alt", {
+        selector: "body > img",
+        anchor: "data-id=hero",
+        htmlFingerprint: "aaa",
+      }),
+    ];
+    const current = [
+      item("img-alt", {
+        selector: "main > figure > img",
+        anchor: "data-id=hero",
+        htmlFingerprint: "bbb",
+      }),
+    ];
+    const result = diff(baseline, current, [T1v, T2]);
+    expect(result.healed).toHaveLength(1);
+    expect(result.healed[0].tier).toBe("anchor");
+    expect(result.refused).toHaveLength(0);
+  });
+
+  it("leaves the uniqueness gate counting raw candidates, refusals included", () => {
+    const baseline = [
+      item("img-alt", {
+        selector: "s1",
+        htmlFingerprint: "aaa",
+        relativeLocation: "main",
+        tag: "img",
+      }),
+      item("img-alt", {
+        selector: "s2",
+        htmlFingerprint: "ccc",
+        relativeLocation: "main",
+        tag: "img",
+      }),
+    ];
+    const current = [
+      item("img-alt", {
+        selector: "s1",
+        htmlFingerprint: "bbb",
+        relativeLocation: "main",
+        tag: "img",
+      }),
+    ];
+    const result = diff(baseline, current, [T1v, T6]);
+    expect(result.healed).toHaveLength(0);
+    expect(result.new).toHaveLength(1);
+    expect(result.fixed).toHaveLength(2);
+  });
+
+  it("keeps a refused pair out of likelyMoved", () => {
+    const baseline = [
+      item("img-alt", {
+        selector: "getByTestId('hero')",
+        anchor: "data-testid=hero",
+        htmlFingerprint: "aaa",
+        relativeLocation: "main",
+        tag: "img",
+      }),
+    ];
+    const current = [
+      item("img-alt", {
+        selector: "getByTestId('hero')",
+        anchor: "data-testid=hero",
+        htmlFingerprint: "bbb",
+        relativeLocation: "main",
+        tag: "img",
+      }),
+    ];
+    const result = diff(baseline, current, [T1v, T2]);
+    expect(result.new).toHaveLength(1);
+    expect(result.likelyMoved).toHaveLength(0);
   });
 });
 

--- a/heal-diff/src/diff.ts
+++ b/heal-diff/src/diff.ts
@@ -7,6 +7,10 @@
  * are preserved. Each tier names a subset of signal keys that all must
  * match; matches at a non-T1 heal tier land in `healed` and carry the
  * replacement pair.
+ *
+ * A tier with `verifiedBy` can refuse a candidate pair, and refusals are
+ * remembered for the rest of the run so a weaker tier cannot re-pair the
+ * same two items unverified. Unresolved refusals surface in `refused`.
  */
 
 export type TierKey<Sig extends string> = "id" | Sig;
@@ -29,6 +33,11 @@ export interface Tier<Sig extends string = string> {
    * are released to later tiers (refuse-and-release). Either side lacking
    * the signal leaves the match standing (missing-signal leniency), so
    * signal-less baseline rows still match by the tier key alone.
+   *
+   * A refusal is remembered for the rest of the run: it means "these two are
+   * not the same element", which stays true at every weaker tier, so the pair
+   * can never re-match further down. Each item is still free to match anyone
+   * else, which is what keeps swapped elements healing to their true partners.
    */
   verifiedBy?: Sig;
 }
@@ -40,6 +49,21 @@ export interface MatchedPair<Sig extends string> {
 }
 
 export type HealedPair<Sig extends string> = MatchedPair<Sig>;
+
+/**
+ * A candidate pair a verified tier refused: both items carried the tier's
+ * verification signal and the values disagreed. Reported only when the
+ * current item ends the run unmatched, since that is the case a caller has
+ * to explain to a developer.
+ */
+export interface RefusedPair<Sig extends string> {
+  baseline: DiffItem<Sig>;
+  current: DiffItem<Sig>;
+  /** Tier that refused — the tier at which the two items met. */
+  tier: string;
+  /** Signal whose values disagreed. */
+  signal: Sig;
+}
 
 export interface LikelyMoved<Sig extends string> {
   current: DiffItem<Sig>;
@@ -68,6 +92,7 @@ export interface DiffResult<Sig extends string> {
   fixed: DiffItem<Sig>[];
   new: DiffItem<Sig>[];
   likelyMoved: LikelyMoved<Sig>[];
+  refused: RefusedPair<Sig>[];
   newGroups?: Group<Sig>[];
   fixedGroups?: Group<Sig>[];
   likelyMovedGroups?: Group<Sig>[];
@@ -97,16 +122,66 @@ function verificationPasses<Sig extends string>(
   return av === bv;
 }
 
+/**
+ * Refusals recorded so far, keyed on object identity (current -> baseline).
+ * Identity, not signal values: `diff()` keeps the caller's `DiffItem`
+ * references throughout the tier loop and matching is count-based, so two
+ * items with identical signals are still distinct items. Value-keying would
+ * refuse both when only one was refused.
+ */
+type RefusalMemory<Sig extends string> = Map<DiffItem<Sig>, Map<DiffItem<Sig>, RefusedPair<Sig>>>;
+
+function recordRefusal<Sig extends string>(
+  memory: RefusalMemory<Sig>,
+  pair: RefusedPair<Sig>,
+): void {
+  let perCurrent = memory.get(pair.current);
+  if (!perCurrent) {
+    perCurrent = new Map();
+    memory.set(pair.current, perCurrent);
+  }
+  if (!perCurrent.has(pair.baseline)) perCurrent.set(pair.baseline, pair);
+}
+
+function isRefused<Sig extends string>(
+  memory: RefusalMemory<Sig>,
+  curr: DiffItem<Sig>,
+  baseline: DiffItem<Sig>,
+): boolean {
+  return memory.get(curr)?.has(baseline) ?? false;
+}
+
+/**
+ * Take the first bucket candidate that neither carries a standing refusal
+ * with `curr` nor fails this tier's verification. Candidates rejected on
+ * verification are remembered so no weaker tier re-pairs them.
+ *
+ * The uniqueness gate counts raw `bucket.length`, refusals included, so a
+ * refusal can only ever subtract a heal, never create one.
+ */
 function consumeFromBucket<Sig extends string>(
   bucket: DiffItem<Sig>[] | undefined,
   tier: Tier<Sig>,
   curr: DiffItem<Sig>,
+  memory: RefusalMemory<Sig>,
 ): DiffItem<Sig> | null {
   if (!bucket || bucket.length === 0) return null;
   if ((tier.uniquenessGated ?? false) && bucket.length > 1) return null;
-  const index = bucket.findIndex((cand) => verificationPasses(curr, cand, tier.verifiedBy));
-  if (index === -1) return null;
-  return bucket.splice(index, 1)[0];
+  for (let i = 0; i < bucket.length; i++) {
+    const cand = bucket[i];
+    if (isRefused(memory, curr, cand)) continue;
+    if (!verificationPasses(curr, cand, tier.verifiedBy)) {
+      recordRefusal(memory, {
+        baseline: cand,
+        current: curr,
+        tier: tier.name,
+        signal: tier.verifiedBy as Sig,
+      });
+      continue;
+    }
+    return bucket.splice(i, 1)[0];
+  }
+  return null;
 }
 
 function bucketize<Sig extends string>(
@@ -142,6 +217,7 @@ export function diff<Sig extends string>(
   const currentRemaining = [...current];
   const matched: MatchedPair<Sig>[] = [];
   const healed: HealedPair<Sig>[] = [];
+  const refusals: RefusalMemory<Sig> = new Map();
 
   for (const tier of tiers) {
     if (currentRemaining.length === 0 || baselineRemaining.length === 0) break;
@@ -155,7 +231,7 @@ export function diff<Sig extends string>(
         stillUnmatchedCurrent.push(curr);
         continue;
       }
-      const picked = consumeFromBucket(baselineBuckets.get(k), tier, curr);
+      const picked = consumeFromBucket(baselineBuckets.get(k), tier, curr, refusals);
       if (picked == null) {
         stillUnmatchedCurrent.push(curr);
         continue;
@@ -179,7 +255,16 @@ export function diff<Sig extends string>(
   const fixed = baselineRemaining.slice();
   const newItems = currentRemaining.slice();
 
-  const likelyMoved = detectLikelyMoved(newItems, fixed);
+  const likelyMoved = detectLikelyMoved(newItems, fixed, refusals);
+
+  // A refusal is only worth reporting when it left the current item unmatched;
+  // a pair refused at T1 that healed to its true partner later has nothing to
+  // explain.
+  const refused: RefusedPair<Sig>[] = [];
+  for (const curr of newItems) {
+    const perCurrent = refusals.get(curr);
+    if (perCurrent) refused.push(...perCurrent.values());
+  }
 
   const result: DiffResult<Sig> = {
     matched,
@@ -187,6 +272,7 @@ export function diff<Sig extends string>(
     fixed,
     new: newItems,
     likelyMoved,
+    refused,
   };
 
   if (options?.grouping) {
@@ -206,6 +292,7 @@ const LIKELY_SIGNALS = ["tag", "htmlFingerprint", "relativeLocation"] as const;
 function detectLikelyMoved<Sig extends string>(
   newItems: readonly DiffItem<Sig>[],
   fixedItems: readonly DiffItem<Sig>[],
+  refusals: RefusalMemory<Sig>,
 ): LikelyMoved<Sig>[] {
   if (newItems.length === 0 || fixedItems.length === 0) return [];
 
@@ -217,6 +304,9 @@ function detectLikelyMoved<Sig extends string>(
     for (const cand of fixedItems) {
       if (fixedClaimed.has(cand)) continue;
       if (cand.id !== curr.id) continue;
+      // A refused pair is known not to be the same element; "likely moved"
+      // would coach the developer into accepting an impostor.
+      if (isRefused(refusals, curr, cand)) continue;
       const shared: string[] = [];
       for (const sig of LIKELY_SIGNALS) {
         const a = curr.signals[sig as Sig];

--- a/heal-diff/src/index.ts
+++ b/heal-diff/src/index.ts
@@ -5,6 +5,7 @@ export type {
   MatchedPair,
   HealedPair,
   LikelyMoved,
+  RefusedPair,
   Group,
   GroupingConfig,
   DiffOptions,

--- a/matchers-internal/src/matchers.ts
+++ b/matchers-internal/src/matchers.ts
@@ -17,6 +17,7 @@ import { getCachedAudit, isFixtureActive, setCachedAudit } from "./cache";
 import {
   evaluateSnapshot,
   isUpdateMode,
+  refusedHealLines,
   resolveSnapshotPath,
   toSnapshotViolations,
   validateSnapshotName,
@@ -132,9 +133,7 @@ function snapshotMessage(snap: SnapshotResult, name: string, current: SnapshotVi
     }
 
     for (const h of snap.healed) {
-      parts.push(
-        `  healed ${h.ruleId} via ${h.tier}: ${h.oldSelector} -> ${h.newSelector}`,
-      );
+      parts.push(`  healed ${h.ruleId} via ${h.tier}: ${h.oldSelector} -> ${h.newSelector}`);
     }
 
     return parts.join("\n");
@@ -147,6 +146,11 @@ function snapshotMessage(snap: SnapshotResult, name: string, current: SnapshotVi
   );
   for (const v of snap.newViolations) {
     lines.push(`  ${v.ruleId}: ${v.selector}`);
+    const refused = snap.refused.find((r) => r.current.selector === v.selector);
+    if (refused) {
+      lines.push(...refusedHealLines(refused));
+      continue;
+    }
     const hint = snap.likelyMoved.find((lm) => lm.current.selector === v.selector);
     if (hint) {
       lines.push(`    likely moved from: ${hint.candidate.selector}`);

--- a/matchers-internal/src/snapshot.test.ts
+++ b/matchers-internal/src/snapshot.test.ts
@@ -12,6 +12,7 @@ import {
   historyPathFor,
   HISTORY_FILENAME,
   loadSnapshot,
+  refusedHealLines,
   resolveSnapshotPath,
   saveSnapshot,
   screenshotsDirFor,
@@ -386,6 +387,31 @@ describe("diffSnapshots — healing tiers", () => {
     expect(d.healed).toHaveLength(0);
   });
 
+  it("surfaces a refused heal and drops the likelyMoved hint for that pair", () => {
+    const shared = {
+      ruleId: "text-alternatives/img-alt",
+      selector: "getByTestId('hero')",
+      anchor: "data-testid=hero",
+      relativeLocation: "main",
+      tag: "img",
+    };
+    const baseline: SnapshotViolation[] = [{ ...shared, htmlFingerprint: "aaa" }];
+    const current: SnapshotViolation[] = [{ ...shared, htmlFingerprint: "bbb" }];
+
+    const d = diffSnapshots(current, baseline);
+    expect(d.healed).toHaveLength(0);
+    expect(d.newViolations).toHaveLength(1);
+    expect(d.fixedViolations).toHaveLength(1);
+    expect(d.refused).toHaveLength(1);
+    expect(d.refused[0].ruleId).toBe("text-alternatives/img-alt");
+    expect(d.refused[0].signal).toBe("htmlFingerprint");
+    expect(d.refused[0].tier).toBe("exact");
+    expect(d.refused[0].candidate.htmlFingerprint).toBe("aaa");
+    expect(d.refused[0].current.htmlFingerprint).toBe("bbb");
+    // tag + relativeLocation would otherwise clear the hint threshold.
+    expect(d.likelyMoved).toHaveLength(0);
+  });
+
   it("surfaces likelyMoved when healing fails but signals partially overlap", () => {
     const baseline: SnapshotViolation[] = [
       {
@@ -409,6 +435,81 @@ describe("diffSnapshots — healing tiers", () => {
     expect(d.healed).toHaveLength(1);
     expect(d.healed[0].tier).toBe("htmlFingerprint");
     expect(d.likelyMoved).toHaveLength(0);
+  });
+});
+
+describe("refusedHealLines", () => {
+  const base = {
+    ruleId: "text-alternatives/img-alt",
+    signal: "htmlFingerprint",
+    tier: "exact",
+  };
+
+  it("names the disagreeing signal and the anchor an impostor could be reusing", () => {
+    const lines = refusedHealLines({
+      ...base,
+      current: {
+        ruleId: base.ruleId,
+        selector: "getByTestId('hero')",
+        anchor: "data-testid=hero",
+      },
+      candidate: {
+        ruleId: base.ruleId,
+        selector: "getByTestId('hero')",
+        anchor: "data-testid=hero",
+      },
+    });
+    expect(lines).toEqual([
+      "    refused to heal: htmlFingerprint at this selector differs from the baseline",
+      "    either you edited this element, or a different element now uses data-testid=hero",
+      "    if you edited it: run with ACCESSLINT_UPDATE=1",
+    ]);
+  });
+
+  it("does not claim an anchor when the element has none", () => {
+    const lines = refusedHealLines({
+      ...base,
+      current: { ruleId: base.ruleId, selector: "body > img" },
+      candidate: { ruleId: base.ruleId, selector: "body > img" },
+    });
+    expect(lines[1]).toContain("or a different element now sits at this selector");
+  });
+
+  it("prints both screenshots only when they are genuinely different images", () => {
+    const withPaths = (baselineShot: string, currentShot: string) =>
+      refusedHealLines({
+        ...base,
+        current: {
+          ruleId: base.ruleId,
+          selector: "getByTestId('hero')",
+          screenshotPath: currentShot,
+        },
+        candidate: {
+          ruleId: base.ruleId,
+          selector: "getByTestId('hero')",
+          screenshotPath: baselineShot,
+        },
+      });
+
+    expect(withPaths("g/a_aaaaaaaa.png", "g/a_bbbbbbbb.png").slice(-2)).toEqual([
+      "    baseline screenshot: g/a_aaaaaaaa.png",
+      "    current screenshot:  g/a_bbbbbbbb.png",
+    ]);
+    expect(withPaths("g/a.png", "g/a.png").join("\n")).not.toContain("screenshot:");
+  });
+
+  it("takes a runner-specific update hint", () => {
+    const lines = refusedHealLines(
+      {
+        ...base,
+        current: { ruleId: base.ruleId, selector: "body > img" },
+        candidate: { ruleId: base.ruleId, selector: "body > img" },
+      },
+      { updateHint: "re-run with --update-snapshot or ACCESSLINT_UPDATE=1" },
+    );
+    expect(lines[2]).toBe(
+      "    if you edited it: re-run with --update-snapshot or ACCESSLINT_UPDATE=1",
+    );
   });
 });
 

--- a/matchers-internal/src/snapshot.ts
+++ b/matchers-internal/src/snapshot.ts
@@ -58,6 +58,22 @@ export interface LikelyMovedHint {
   sharedSignals: string[];
 }
 
+/**
+ * A heal the matcher refused: the pair met at a verified tier and the
+ * verification signal disagreed, so `current` is reported new rather than
+ * healed onto `candidate`. Mirrors `LikelyMovedHint`, and replaces it for
+ * the pairs it covers — a refusal is a decision, not a guess.
+ */
+export interface RefusedHeal {
+  ruleId: string;
+  current: SnapshotViolation;
+  candidate: SnapshotViolation;
+  /** Signal whose values disagreed, e.g. "htmlFingerprint". */
+  signal: string;
+  /** Tier at which the two met. */
+  tier: string;
+}
+
 export interface RefreshedViolation {
   ruleId: string;
   selector: string;
@@ -71,8 +87,45 @@ export interface SnapshotResult {
   healed: HealedViolation[];
   refreshed: RefreshedViolation[];
   likelyMoved: LikelyMovedHint[];
+  refused: RefusedHeal[];
   updated: boolean;
   created: boolean;
+}
+
+/**
+ * Explain one refused heal, as indented lines under the violation it
+ * belongs to. Shared by every render site (jest/vitest, playwright, cli) so
+ * the wording stays in one place.
+ *
+ * Names the disagreeing signal and gives both causes with the action for
+ * each. Raw hashes are omitted deliberately — 12 hex chars tell a human
+ * nothing; the two screenshots are what make the call decidable, so they
+ * are printed whenever both exist and are genuinely different images.
+ */
+export function refusedHealLines(
+  refused: RefusedHeal,
+  options?: { indent?: string; updateHint?: string },
+): string[] {
+  const indent = options?.indent ?? "    ";
+  const updateHint = options?.updateHint ?? "run with ACCESSLINT_UPDATE=1";
+  const anchor = refused.current.anchor ?? refused.candidate.anchor;
+
+  const lines = [
+    `${indent}refused to heal: ${refused.signal} at this selector differs from the baseline`,
+    anchor
+      ? `${indent}either you edited this element, or a different element now uses ${anchor}`
+      : `${indent}either you edited this element, or a different element now sits at this selector`,
+    `${indent}if you edited it: ${updateHint}`,
+  ];
+
+  const baselineShot = refused.candidate.screenshotPath;
+  const currentShot = refused.current.screenshotPath;
+  if (baselineShot && currentShot && baselineShot !== currentShot) {
+    lines.push(`${indent}baseline screenshot: ${baselineShot}`);
+    lines.push(`${indent}current screenshot:  ${currentShot}`);
+  }
+
+  return lines;
 }
 
 export type HistoryEvent = "created" | "ratchet-down" | "force-update" | "healed" | "refreshed";
@@ -269,6 +322,7 @@ export function diffSnapshots(
   healed: HealedViolation[];
   refreshed: RefreshedViolation[];
   likelyMoved: LikelyMovedHint[];
+  refused: RefusedHeal[];
   reconciledBaseline: SnapshotViolation[];
   raw: DiffResult<AccesslintSignal>;
 } {
@@ -294,6 +348,14 @@ export function diffSnapshots(
     current: fromDiffItem(lm.current),
     candidate: fromDiffItem(lm.candidate),
     sharedSignals: lm.sharedSignals,
+  }));
+
+  const refused: RefusedHeal[] = result.refused.map((r) => ({
+    ruleId: r.current.id,
+    current: fromDiffItem(r.current),
+    candidate: fromDiffItem(r.baseline),
+    signal: r.signal,
+    tier: r.tier,
   }));
 
   // Reconciled baseline: exact matches carry forward but refresh any signals
@@ -326,6 +388,7 @@ export function diffSnapshots(
     healed,
     refreshed,
     likelyMoved,
+    refused,
     reconciledBaseline,
     raw: result,
   };
@@ -400,6 +463,7 @@ export function evaluateSnapshot(
       healed: [],
       refreshed: [],
       likelyMoved: [],
+      refused: [],
       updated: false,
       created: true,
     };
@@ -427,6 +491,7 @@ export function evaluateSnapshot(
       healed: [],
       refreshed: [],
       likelyMoved: [],
+      refused: [],
       updated: true,
       created: false,
     };
@@ -487,6 +552,7 @@ export function evaluateSnapshot(
     healed: d.healed,
     refreshed: d.refreshed,
     likelyMoved: d.likelyMoved,
+    refused: d.refused,
     updated: shouldRewrite,
     created: false,
   };

--- a/playwright/src/matchers.ts
+++ b/playwright/src/matchers.ts
@@ -14,6 +14,7 @@ import {
   validateSnapshotName,
   resolveSnapshotPath,
   evaluateSnapshot,
+  refusedHealLines,
   waitForPageSettle,
   toStableViolations,
 } from "./snapshot";
@@ -112,6 +113,11 @@ export async function toBeAccessible(target: Page | Locator, options?: SnapshotM
         ];
         for (const v of snap.newViolations) {
           lines.push(`  ${v.ruleId}: ${v.selector}`);
+          const refused = snap.refused.find((r) => r.current.selector === v.selector);
+          if (refused) {
+            lines.push(...refusedHealLines(refused));
+            continue;
+          }
           const hint = snap.likelyMoved.find((lm) => lm.current.selector === v.selector);
           if (hint) {
             lines.push(`    likely moved from: ${hint.candidate.selector}`);

--- a/playwright/src/snapshot.test.ts
+++ b/playwright/src/snapshot.test.ts
@@ -11,6 +11,11 @@ import {
   evaluateSnapshot,
 } from "./snapshot";
 import type { SnapshotViolation } from "./snapshot";
+// `historyPathFor` isn't re-exported by ./snapshot; matchers-internal is a
+// devDependency, so read the sidecar path from the source of truth.
+import { historyPathFor } from "@accesslint/matchers-internal/snapshot";
+import type { HistoryRecord } from "@accesslint/matchers-internal/snapshot";
+import { toBeAccessible } from "./matchers";
 
 // Auto-register toBeAccessible matcher
 import "./index";
@@ -75,6 +80,25 @@ function createTempDir(): string {
   );
   mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+function readHistory(snapshotPath: string): HistoryRecord[] {
+  const path = historyPathFor(snapshotPath);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf-8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as HistoryRecord);
+}
+
+function healEvents(snapshotPath: string): HistoryRecord[] {
+  return readHistory(snapshotPath).filter((r) => r.event === "healed");
+}
+
+function requireBaseline(snapshotPath: string): SnapshotViolation[] {
+  const baseline = loadSnapshot(snapshotPath);
+  expect(baseline).not.toBeNull();
+  return baseline!;
 }
 
 // ── Unit tests ─────────────────────────────────────────────────────────────
@@ -591,5 +615,309 @@ test.describe("toBeAccessible with snapshot", () => {
     });
 
     rmSync(dir, { recursive: true });
+  });
+});
+
+// ── Healing end-to-end (real Chromium: audit → signal capture → tiered diff) ──
+//
+// Implements RFC validation item 1 (heal-diff/docs/RFC-multi-signal-healing.md,
+// "synthetic fixture corpus") at the browser level. Every fixture below was
+// confirmed with a throwaway probe that printed the captured
+// SnapshotViolation[] for both versions; the recorded facts are what each
+// assertion depends on.
+//
+// The hard part is making the stable selector actually differ: `normalize()`
+// is designed to survive refactors, so a naive before/after pair exact-matches
+// at T1 and never exercises healing. Notably `data-testid` is *also*
+// Playwright's testIdAttribute, so an anchored element normalizes to
+// `getByTestId(...)` — position-independent, always T1. The fixtures use
+// `data-id` (an accesslint anchor attr Playwright ignores) plus duplicate
+// same-role/same-text siblings, which forces positional disambiguation.
+
+/**
+ * T2 fixture. Violating `<img data-id="hero">` beside a NON-violating named
+ * look-alike, so exactly one violation. Probe-confirmed: `getByRole('img')`
+ * matches both images, so normalize disambiguates positionally
+ * (`.first()` → `.nth(1)` after the reorder) while `data-id=hero` survives.
+ */
+const ANCHOR_HEAL_BEFORE = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Gallery</title></head>
+<body>
+  <main>
+    <h1>Gallery</h1>
+    <img data-id="hero" src="hero.png">
+    <img src="team.png" alt="Team photo">
+  </main>
+</body>
+</html>`;
+
+const ANCHOR_HEAL_AFTER = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Gallery</title></head>
+<body>
+  <main>
+    <h1>Gallery</h1>
+    <img src="team.png" alt="Team photo">
+    <img data-id="hero" src="hero.png">
+  </main>
+</body>
+</html>`;
+
+/**
+ * T5 fixture. `<div tabindex="1">` is role-less, so the role tier (which sits
+ * above htmlFingerprint and would otherwise shadow it) is skipped on both
+ * sides; the div carries no anchor attribute either. Probe-confirmed: the
+ * identical-text twin makes normalize emit `getByText('Widget').nth(1)` →
+ * `.nth(2)` after the reorder ("Widgets" in the `<h1>` is index 0), while the
+ * violating div's own outerHTML — and therefore its htmlFingerprint — is
+ * byte-identical across both versions.
+ */
+const FINGERPRINT_HEAL_BEFORE = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Widgets</title></head>
+<body>
+  <main>
+    <h1>Widgets</h1>
+    <div tabindex="1">Widget</div>
+    <div>Widget</div>
+  </main>
+</body>
+</html>`;
+
+const FINGERPRINT_HEAL_AFTER = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Widgets</title></head>
+<body>
+  <main>
+    <h1>Widgets</h1>
+    <div>Widget</div>
+    <div tabindex="1">Widget</div>
+  </main>
+</body>
+</html>`;
+
+/**
+ * T6 fixture. Two role-less, anchor-less, same-tag violations directly under
+ * `<main>`. Probe-confirmed: both share `relativeLocation` = `main > near
+ * "Widgets"` and `tag` = `div` in both versions, and the refactor changes
+ * BOTH elements' text, so all four htmlFingerprints are distinct. Every
+ * stronger tier therefore misses and the relativeLocation bucket holds 2
+ * baseline candidates, which the uniqueness gate refuses.
+ */
+const AMBIGUOUS_BEFORE = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Widgets</title></head>
+<body>
+  <main>
+    <h1>Widgets</h1>
+    <div tabindex="1">Alpha</div>
+    <div tabindex="2">Beta</div>
+  </main>
+</body>
+</html>`;
+
+const AMBIGUOUS_AFTER = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Widgets</title></head>
+<body>
+  <main>
+    <h1>Widgets</h1>
+    <section><div tabindex="1">Alpha renamed</div></section>
+    <section><div tabindex="2">Beta renamed</div></section>
+  </main>
+</body>
+</html>`;
+
+/**
+ * Negative-control fixture. Probe-confirmed: the kept violation normalizes to
+ * `getByText('Alpha')` in both versions, so it T1-matches and leaves no
+ * unmatched baseline entry for a weaker tier to hand to the newcomer.
+ */
+const NEW_VIOLATION_BEFORE = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Widgets</title></head>
+<body>
+  <main>
+    <h1>Widgets</h1>
+    <div tabindex="1">Alpha</div>
+  </main>
+</body>
+</html>`;
+
+const NEW_VIOLATION_AFTER = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Widgets</title></head>
+<body>
+  <main>
+    <h1>Widgets</h1>
+    <div tabindex="1">Alpha</div>
+    <div tabindex="3">Gamma</div>
+  </main>
+</body>
+</html>`;
+
+test.describe("toBeAccessible with snapshot — healing (e2e)", () => {
+  test("heals at the anchor tier when the stable selector moves", async ({ page }) => {
+    const dir = createTempDir();
+    const snapshotPath = join(dir, "anchor-heal.json");
+
+    try {
+      await page.setContent(ANCHOR_HEAL_BEFORE);
+      await expect(page).toBeAccessible({
+        snapshot: "anchor-heal",
+        snapshotDir: dir,
+        visualSnapshots: false,
+      });
+
+      const baseline = requireBaseline(snapshotPath);
+      expect(baseline).toHaveLength(1);
+      expect(baseline[0].ruleId).toBe("text-alternatives/img-alt");
+      expect(baseline[0].selector).toBe("getByRole('img').first()");
+      expect(baseline[0].anchor).toBe("data-id=hero");
+      // In-browser captureMainFrameSignals produced a real fingerprint.
+      expect(baseline[0].htmlFingerprint).toMatch(/^[0-9a-f]{12}$/);
+
+      await page.setContent(ANCHOR_HEAL_AFTER);
+      await expect(page).toBeAccessible({
+        snapshot: "anchor-heal",
+        snapshotDir: dir,
+        visualSnapshots: false,
+      });
+
+      const healed = requireBaseline(snapshotPath);
+      expect(healed).toHaveLength(1);
+      expect(healed[0].selector).toBe("getByRole('img').nth(1)");
+      expect(healed[0].anchor).toBe("data-id=hero");
+
+      const heals = healEvents(snapshotPath);
+      expect(heals).toHaveLength(1);
+      expect(heals[0].healedTier).toBe("anchor");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("heals at the htmlFingerprint tier when no anchor or role is available", async ({
+    page,
+  }) => {
+    const dir = createTempDir();
+    const snapshotPath = join(dir, "fingerprint-heal.json");
+
+    try {
+      await page.setContent(FINGERPRINT_HEAL_BEFORE);
+      await expect(page).toBeAccessible({
+        snapshot: "fingerprint-heal",
+        snapshotDir: dir,
+        visualSnapshots: false,
+      });
+
+      const baseline = requireBaseline(snapshotPath);
+      expect(baseline).toHaveLength(1);
+      expect(baseline[0].ruleId).toBe("keyboard-accessible/tabindex");
+      expect(baseline[0].selector).toBe("getByText('Widget').nth(1)");
+      // The tiers above htmlFingerprint have nothing to key on.
+      expect(baseline[0].anchor).toBeUndefined();
+      expect(baseline[0].role).toBeUndefined();
+      const fingerprint = baseline[0].htmlFingerprint;
+      expect(fingerprint).toMatch(/^[0-9a-f]{12}$/);
+
+      await page.setContent(FINGERPRINT_HEAL_AFTER);
+      await expect(page).toBeAccessible({
+        snapshot: "fingerprint-heal",
+        snapshotDir: dir,
+        visualSnapshots: false,
+      });
+
+      const healed = requireBaseline(snapshotPath);
+      expect(healed).toHaveLength(1);
+      expect(healed[0].selector).toBe("getByText('Widget').nth(2)");
+      expect(healed[0].htmlFingerprint).toBe(fingerprint);
+
+      const heals = healEvents(snapshotPath);
+      expect(heals).toHaveLength(1);
+      expect(heals[0].healedTier).toBe("htmlFingerprint");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("uniqueness gate refuses to heal two ambiguous look-alikes", async ({ page }) => {
+    const dir = createTempDir();
+    const snapshotPath = join(dir, "ambiguous.json");
+
+    try {
+      await page.setContent(AMBIGUOUS_BEFORE);
+      await expect(page).toBeAccessible({
+        snapshot: "ambiguous",
+        snapshotDir: dir,
+        visualSnapshots: false,
+      });
+      expect(requireBaseline(snapshotPath)).toHaveLength(2);
+
+      await page.setContent(AMBIGUOUS_AFTER);
+      const result = await toBeAccessible(page, {
+        snapshot: "ambiguous",
+        snapshotDir: dir,
+        visualSnapshots: false,
+      });
+
+      expect(result.pass).toBe(false);
+      const message = result.message();
+      expect(message).toContain("found 2 new");
+      expect(message).toContain("likely moved from:");
+      expect(message).toContain("matched on: tag, relativeLocation");
+
+      expect(healEvents(snapshotPath)).toHaveLength(0);
+
+      // Failing run leaves the baseline untouched.
+      const after = requireBaseline(snapshotPath);
+      expect(after.map((v) => v.selector).sort()).toEqual([
+        "getByText('Alpha')",
+        "getByText('Beta')",
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a genuinely new violation is reported, never healed", async ({ page }) => {
+    const dir = createTempDir();
+    const snapshotPath = join(dir, "new-violation.json");
+
+    try {
+      await page.setContent(NEW_VIOLATION_BEFORE);
+      await expect(page).toBeAccessible({
+        snapshot: "new-violation",
+        snapshotDir: dir,
+        visualSnapshots: false,
+      });
+      expect(requireBaseline(snapshotPath)).toHaveLength(1);
+
+      await page.setContent(NEW_VIOLATION_AFTER);
+      const result = await toBeAccessible(page, {
+        snapshot: "new-violation",
+        snapshotDir: dir,
+        visualSnapshots: false,
+      });
+
+      expect(result.pass).toBe(false);
+      const message = result.message();
+      expect(message).toContain("found 1 new");
+      expect(message).toContain("getByText('Gamma')");
+      expect(message).not.toContain("getByText('Alpha')");
+
+      expect(healEvents(snapshotPath)).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/playwright/src/snapshot.test.ts
+++ b/playwright/src/snapshot.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, rmSync, readFileSync, readdirSync, existsSync } from "node:fs";
+import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   validateSnapshotName,
@@ -765,6 +765,38 @@ const NEW_VIOLATION_AFTER = `
 </body>
 </html>`;
 
+/**
+ * Impostor fixture. Both versions carry the same `data-testid`, so both
+ * normalize to `getByTestId('hero')` and the `anchor` signal is a strict
+ * function of the selector — the case where T1's verification used to buy
+ * nothing, since the anchor tier re-paired the refused pair one tier later.
+ * The `src` change moves the htmlFingerprint (inline `style` is dropped by
+ * normalization, so it colors the screenshots without touching identity).
+ */
+const IMPOSTOR_BEFORE = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Gallery</title></head>
+<body>
+  <main>
+    <h1>Gallery</h1>
+    <img data-testid="hero" src="hero.png" style="width:200px;height:100px;background:#c00">
+  </main>
+</body>
+</html>`;
+
+const IMPOSTOR_AFTER = `
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Gallery</title></head>
+<body>
+  <main>
+    <h1>Gallery</h1>
+    <img data-testid="hero" src="banner.png" style="width:200px;height:100px;background:#00c">
+  </main>
+</body>
+</html>`;
+
 test.describe("toBeAccessible with snapshot — healing (e2e)", () => {
   test("heals at the anchor tier when the stable selector moves", async ({ page }) => {
     const dir = createTempDir();
@@ -916,6 +948,39 @@ test.describe("toBeAccessible with snapshot — healing (e2e)", () => {
       expect(message).not.toContain("getByText('Alpha')");
 
       expect(healEvents(snapshotPath)).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+test.describe("screenshot filenames", () => {
+  test("an anchored element keeps its baseline image when the markup changes", async ({ page }) => {
+    const dir = createTempDir();
+    const snapshotPath = join(dir, "shots.json");
+    const shotsDir = join(dir, "shots-screenshots");
+
+    try {
+      await page.setContent(IMPOSTOR_BEFORE);
+      await expect(page).toBeAccessible({ snapshot: "shots", snapshotDir: dir });
+
+      const baselineShot = requireBaseline(snapshotPath)[0].screenshotPath;
+      expect(baselineShot).toBeTruthy();
+      expect(readdirSync(shotsDir)).toEqual([basename(baselineShot!)]);
+
+      // Same anchor, same selector, different markup. Discriminating on the
+      // anchor alone computed the same path here and overwrote the baseline.
+      await page.setContent(IMPOSTOR_AFTER);
+      await toBeAccessible(page, { snapshot: "shots", snapshotDir: dir });
+
+      const files = readdirSync(shotsDir).sort();
+      expect(files).toHaveLength(2);
+      expect(files).toContain(basename(baselineShot!));
+      for (const file of files) {
+        expect(file).toContain("data-testid-hero");
+      }
+      const [a, b] = files.map((f) => readFileSync(join(shotsDir, f)));
+      expect(a.equals(b)).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/playwright/src/snapshot.test.ts
+++ b/playwright/src/snapshot.test.ts
@@ -921,6 +921,50 @@ test.describe("toBeAccessible with snapshot — healing (e2e)", () => {
     }
   });
 
+  test("refuses to heal an impostor reusing a data-testid, and says why", async ({ page }) => {
+    const dir = createTempDir();
+    const snapshotPath = join(dir, "impostor.json");
+
+    try {
+      await page.setContent(IMPOSTOR_BEFORE);
+      await expect(page).toBeAccessible({ snapshot: "impostor", snapshotDir: dir });
+
+      const baseline = requireBaseline(snapshotPath);
+      expect(baseline).toHaveLength(1);
+      expect(baseline[0].selector).toBe("getByTestId('hero')");
+      expect(baseline[0].anchor).toBe("data-testid=hero");
+      const baselineFingerprint = baseline[0].htmlFingerprint;
+      expect(baselineFingerprint).toMatch(/^[0-9a-f]{12}$/);
+
+      await page.setContent(IMPOSTOR_AFTER);
+      const result = await toBeAccessible(page, { snapshot: "impostor", snapshotDir: dir });
+
+      expect(result.pass).toBe(false);
+      const message = result.message();
+      expect(message).toContain("found 1 new");
+      expect(message).toContain("refused to heal");
+      expect(message).toContain("htmlFingerprint");
+      expect(message).toContain("data-testid=hero");
+      // The hint layer must not also fire: it would coach the developer into
+      // adding a data-testid the element already has.
+      expect(message).not.toContain("likely moved from");
+
+      const shots = message
+        .split("\n")
+        .filter((line) => line.includes("screenshot:"))
+        .map((line) => line.split(":").pop()!.trim());
+      expect(shots).toHaveLength(2);
+      expect(shots[0]).not.toBe(shots[1]);
+      for (const shot of shots) expect(existsSync(join(dir, shot))).toBe(true);
+
+      expect(healEvents(snapshotPath)).toHaveLength(0);
+      // A failing run leaves the baseline alone.
+      expect(requireBaseline(snapshotPath)[0].htmlFingerprint).toBe(baselineFingerprint);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("a genuinely new violation is reported, never healed", async ({ page }) => {
     const dir = createTempDir();
     const snapshotPath = join(dir, "new-violation.json");

--- a/playwright/src/snapshot.ts
+++ b/playwright/src/snapshot.ts
@@ -20,11 +20,13 @@ export {
   saveSnapshot,
   compareViolations,
   evaluateSnapshot,
+  refusedHealLines,
   screenshotsDirFor,
   type SnapshotViolation,
   type SnapshotResult,
   type HealedViolation,
   type LikelyMovedHint,
+  type RefusedHeal,
 } from "@accesslint/matchers-internal/snapshot";
 import type { SnapshotViolation } from "@accesslint/matchers-internal/snapshot";
 

--- a/playwright/src/snapshot.ts
+++ b/playwright/src/snapshot.ts
@@ -361,14 +361,21 @@ function ruleSlug(ruleId: string): string {
   return ruleId.replace(/\//g, "_");
 }
 
+/**
+ * `<rule>_<anchorSlug>_<fp8>.png` — the fingerprint is part of the name, not
+ * a fallback for a missing anchor. Keying on the anchor alone made an
+ * element's baseline and impostor images compute the same path, and since
+ * each run starts with a fresh `used` set, the second run overwrote the
+ * first: no baseline image was ever retained for an anchored element. Both
+ * the refused-heal message and the likely-moved hint are only decidable when
+ * the two images survive side by side.
+ */
 function screenshotFilename(v: SnapshotViolation, existing: Set<string>): string {
-  const rule = ruleSlug(v.ruleId);
-  const disc = v.anchor
-    ? slugForDiscriminator(v.anchor)
-    : v.htmlFingerprint
-      ? v.htmlFingerprint.slice(0, 8)
-      : "x";
-  const base = `${rule}_${disc}`;
+  const parts = [ruleSlug(v.ruleId)];
+  if (v.anchor) parts.push(slugForDiscriminator(v.anchor));
+  if (v.htmlFingerprint) parts.push(v.htmlFingerprint.slice(0, 8));
+  if (parts.length === 1) parts.push("x");
+  const base = parts.join("_");
   let name = `${base}.png`;
   let i = 1;
   while (existing.has(name)) {

--- a/report/src/emit-html.ts
+++ b/report/src/emit-html.ts
@@ -133,14 +133,13 @@ function tableOfContents(report: Report): string {
       const first = s.points[0]?.total ?? 0;
       const last = s.currentTotal;
       const delta = last - first;
-      const deltaText =
-        delta === 0
-          ? "–"
-          : delta > 0
-            ? `+${delta}`
-            : `−${Math.abs(delta)}`;
+      const deltaText = delta === 0 ? "–" : delta > 0 ? `+${delta}` : `−${Math.abs(delta)}`;
       const deltaClass =
-        delta === 0 ? "toc-delta toc-delta-flat" : delta > 0 ? "toc-delta toc-delta-regress" : "toc-delta toc-delta-fix";
+        delta === 0
+          ? "toc-delta toc-delta-flat"
+          : delta > 0
+            ? "toc-delta toc-delta-regress"
+            : "toc-delta toc-delta-fix";
       return `<li><a href="#snapshot-${anchorId(s.name)}"><span class="toc-name">${escapeHtml(s.name)}</span><span class="toc-total">${s.currentTotal}</span><span class="${deltaClass}">${escapeHtml(deltaText)}</span></a></li>`;
     })
     .join("");
@@ -319,7 +318,8 @@ function chartDescription(s: SnapshotTimeline): string {
   );
   parts.push(`Y axis range ${min} to ${max}, currently ${last}.`);
   if (last < first) parts.push(`Reduced by ${first - last} from the initial baseline of ${first}.`);
-  else if (last > first) parts.push(`Increased by ${last - first} from the initial baseline of ${first}.`);
+  else if (last > first)
+    parts.push(`Increased by ${last - first} from the initial baseline of ${first}.`);
   else parts.push(`Unchanged from the initial baseline of ${first}.`);
   if (forceUpdates > 0) {
     parts.push(
@@ -390,7 +390,13 @@ function rulesSection(report: Report): string {
 
 function levelBadge(level: string): string {
   const cls =
-    level === "A" ? "level-a" : level === "AA" ? "level-aa" : level === "AAA" ? "level-aaa" : "level-unknown";
+    level === "A"
+      ? "level-a"
+      : level === "AA"
+        ? "level-aa"
+        : level === "AAA"
+          ? "level-aaa"
+          : "level-unknown";
   return `<span class="level ${cls}">${escapeHtml(level === "unknown" ? "–" : level)}</span>`;
 }
 
@@ -401,8 +407,10 @@ function netClass(n: number): string {
 }
 
 function renderNet(n: number): string {
-  if (n > 0) return `<span class="direction" aria-hidden="true">▲</span><span class="sr-text">increased by </span>${n}`;
-  if (n < 0) return `<span class="direction" aria-hidden="true">▼</span><span class="sr-text">decreased by </span>${Math.abs(n)}`;
+  if (n > 0)
+    return `<span class="direction" aria-hidden="true">▲</span><span class="sr-text">increased by </span>${n}`;
+  if (n < 0)
+    return `<span class="direction" aria-hidden="true">▼</span><span class="sr-text">decreased by </span>${Math.abs(n)}`;
   return `<span class="direction" aria-hidden="true">=</span><span class="sr-text">unchanged</span>0`;
 }
 
@@ -461,11 +469,17 @@ function formatDateTime(iso: string): string {
 function eventGlyph(event: SnapshotTimelinePoint["event"]): string {
   if (event === "created") return "○";
   if (event === "ratchet-down") return "◆";
+  if (event === "healed" || event === "refreshed") return "↻";
   return "▲";
 }
 
 function anchorId(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "unnamed";
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "") || "unnamed"
+  );
 }
 
 function escapeHtml(s: string): string {
@@ -507,7 +521,10 @@ function monthTicks(tMin: number, tMax: number): Array<{ ts: number; label: stri
   const fmt: Intl.DateTimeFormatOptions = { month: "short", timeZone: "UTC" };
   let cursor = new Date(start);
   while (cursor.getTime() <= tMax) {
-    out.push({ ts: cursor.getTime(), label: cursor.toLocaleDateString("en-US", fmt).toUpperCase() });
+    out.push({
+      ts: cursor.getTime(),
+      label: cursor.toLocaleDateString("en-US", fmt).toUpperCase(),
+    });
     cursor = new Date(cursor);
     cursor.setUTCMonth(cursor.getUTCMonth() + stride);
   }
@@ -1015,6 +1032,7 @@ a:hover { color: var(--focus); }
 .tag-created { color: var(--chart-line); border-color: var(--hairline-2); }
 .tag-ratchet-down { background: var(--fix-bg); color: var(--fix); border-color: transparent; }
 .tag-force-update { background: var(--regress-bg); color: var(--regress); border-color: transparent; }
+.tag-healed, .tag-refreshed { color: var(--muted); border-color: var(--hairline-2); }
 
 /* ----- Level badges ----- */
 .level {

--- a/report/src/history.test.ts
+++ b/report/src/history.test.ts
@@ -66,6 +66,40 @@ describe("parseHistory", () => {
     expect(parseHistory(bad + "\n")).toHaveLength(0);
   });
 
+  it("retains healed and refreshed records", () => {
+    const text =
+      [
+        {
+          ts: "2026-04-01T00:00:00Z",
+          name: "home",
+          event: "healed",
+          added: 0,
+          removed: 0,
+          total: 3,
+          addedRules: [],
+          removedRules: [],
+          healedTier: "anchor",
+        },
+        {
+          ts: "2026-04-01T00:01:00Z",
+          name: "home",
+          event: "refreshed",
+          added: 0,
+          removed: 0,
+          total: 3,
+          addedRules: [],
+          removedRules: [],
+          refreshedFields: ["htmlFingerprint"],
+        },
+      ]
+        .map((r) => JSON.stringify(r))
+        .join("\n") + "\n";
+    const records = parseHistory(text);
+    expect(records.map((r) => r.event)).toEqual(["healed", "refreshed"]);
+    expect(records[0].healedTier).toBe("anchor");
+    expect(records[1].refreshedFields).toEqual(["htmlFingerprint"]);
+  });
+
   it("rejects unknown event types", () => {
     const bad = JSON.stringify({
       ts: "2026-04-01T00:00:00Z",

--- a/report/src/history.ts
+++ b/report/src/history.ts
@@ -2,14 +2,23 @@
  * Parse `.history.ndjson` sidecar files emitted by @accesslint/matchers-internal.
  *
  * The sidecar is append-only NDJSON — one record per snapshot write event
- * (`created`, `ratchet-down`, `force-update`). Malformed lines are skipped
- * with a warning rather than aborting, since the file can be concatenated
- * from merge commits or partially written on a crash.
+ * (`created`, `ratchet-down`, `force-update`, `healed`, `refreshed`).
+ * Malformed lines are skipped with a warning rather than aborting, since the
+ * file can be concatenated from merge commits or partially written on a
+ * crash.
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-export type HistoryEvent = "created" | "ratchet-down" | "force-update";
+export type HistoryEvent = "created" | "ratchet-down" | "force-update" | "healed" | "refreshed";
+
+const HISTORY_EVENTS: readonly string[] = [
+  "created",
+  "ratchet-down",
+  "force-update",
+  "healed",
+  "refreshed",
+];
 
 export interface HistoryRecord {
   ts: string;
@@ -20,6 +29,10 @@ export interface HistoryRecord {
   total: number;
   addedRules: string[];
   removedRules: string[];
+  /** Tier that healed the selector. Present on `healed` records only. */
+  healedTier?: string;
+  /** Signal fields refreshed. Present on `refreshed` records only. */
+  refreshedFields?: string[];
 }
 
 const HISTORY_FILENAME = ".history.ndjson";
@@ -46,7 +59,8 @@ function isValid(rec: Partial<HistoryRecord>): rec is HistoryRecord {
   return (
     typeof rec.ts === "string" &&
     typeof rec.name === "string" &&
-    (rec.event === "created" || rec.event === "ratchet-down" || rec.event === "force-update") &&
+    typeof rec.event === "string" &&
+    HISTORY_EVENTS.includes(rec.event) &&
     typeof rec.added === "number" &&
     typeof rec.removed === "number" &&
     typeof rec.total === "number" &&


### PR DESCRIPTION
Closes a soundness hole in `@accesslint/heal-diff`: an impostor that T1 refuses on
`htmlFingerprint` is immediately re-matched, unverified, by the anchor tier. This is the RFC's
"silent false heal" risk, and it was wide open on the most common anchor attribute in the wild.

Discovered while writing the browser-level healing tests in the previous commit on this branch.
That work's flagship anchor fixture had to use `data-id` instead of `data-testid`, because a
`data-testid` element normalizes to `getByTestId(...)` and therefore always T1-matches. The
awkwardness was a smell; following it down found a real defect.

## The defect

`data-testid` is both the `anchor` signal and, since it is Playwright's default
`testIdAttribute`, the `selector`. So for any element carrying one, the anchor tier keys on
exactly the information T1 just rejected:

```
baseline: getByTestId('hero')  anchor data-testid=hero  fp aaa
current:  getByTestId('hero')  anchor data-testid=hero  fp bbb   <- different element

matched: 0 | healed: ["anchor"] | new: 0 | fixed: 0
```

T1 refuses and releases both items; the anchor tier re-pairs them with no verification and
reports a heal. `verifiedBy` on T1 bought nothing for those elements. The existing suite missed
it because its impostor carries no anchor, so the anchor tier could never reach it.

## The fix: refusal memory

A refusal now persists for the run. It means *these two items are not the same element*, which
stays true at every weaker tier, so no later tier may pair them. Each item stays free to match
anyone else.

Both alternatives are worse. Forcing a refused *item* straight to `new` breaks swapped elements,
which are refused at T1 and must still heal to their true partners at T5: the refusal is a fact
about the pair, not about either item. Adding `verifiedBy` tier by tier just walks the silent
heal down the list and terminates only at a global fingerprint gate:

```
current (baseline behavior)        healed=["anchor"]           new=0 fixed=0
(a) verifiedBy on anchor           healed=["role"]             new=0 fixed=0
(b) anchor + role                  healed=["relativeLocation"] new=0 fixed=0
(b+) anchor + role + relLocation   healed=[]                   new=1 fixed=1
```

That gate would refuse the legitimate case where an anchored element moves *and* its markup
churns, which is precisely what the anchor tier exists to survive.

Memory is keyed on object identity, not signal values: matching is count-based and `diff()`
keeps the caller's `DiffItem` references, so two items with identical signals are distinct, and
value-keying would refuse both when only one was refused. The uniqueness gate still counts raw
bucket length, preserving the invariant that **a refusal can only ever subtract a heal, never
create one**.

## The message

Closing the hole converts silent passes into failures, so the failure has to say something true.
The hint layer did not: a refused pair usually shares `tag` and `relativeLocation`, clearing the
likely-moved threshold, and every line it produced was wrong, with the last one coaching the
developer into accepting the impostor.

Refused pairs are now withheld from `likelyMoved` in the engine rather than at each of the three
render sites, and `refusedHealLines` renders the decision from one place. Live output:

```
Expected no new accessibility violations beyond snapshot "impostor", but found 1 new:
  text-alternatives/img-alt: getByTestId('hero')
    refused to heal: htmlFingerprint at this selector differs from the baseline
    either you edited this element, or a different element now uses data-testid=hero
    if you edited it: run with ACCESSLINT_UPDATE=1
    baseline screenshot: impostor-screenshots/text-alternatives_img-alt_data-testid-hero_e8dcdd1c.png
    current screenshot:  impostor-screenshots/text-alternatives_img-alt_data-testid-hero_ce5cb175.png
```

Raw hashes are omitted deliberately: 12 hex chars tell a human nothing, the two images are what
make the call decidable. With no anchor the second line falls back to wording that does not
claim one.

## Two pre-existing bugs found while reading this code

- **Anchored screenshots overwrote each other every run.** `screenshotFilename` derived its
  discriminator from the anchor when one existed, so baseline and impostor computed the same
  path, and each run starts with a fresh in-use set. No baseline image was ever retained for an
  anchored element, which already degraded `likelyMoved`. Names are now content-addressed as
  `<rule>_<anchorSlug>_<fp8>.png`, which is what makes the two paths in the message above real.
- **`@accesslint/report` discarded every `healed` and `refreshed` record at parse time.**
  `HistoryEvent` listed only three events and `isValid` hard-filtered on them, so the report has
  never seen a heal since the RFC landed.

## Verification

- `bun run build`, `bun run test`, `bun run typecheck` green; `playwright test` 68/68, run twice
  back to back to rule out temp-dir or env leakage.
- Mutation check: deleting the refusal lookup in `consumeFromBucket` fails 2 `heal-diff` tests
  and the e2e impostor test. The same treatment of `screenshotFilename` fails the filename
  regression test.
- `lint` and `format:check`: no new findings. Both already fail on pre-existing issues in
  `cli/src/cdp.ts`, `report/*.js` and `core/src/sourcemap/*`; every code file touched here is
  clean. The Prettier reflow in `report/src/emit-html.ts` is pre-existing and unrelated, present
  only because the file is touched.
- RFC updated with the refusal semantics and the deferred limitation below.

## Known limitation, deliberately left open

An impostor reusing a **non-selector** anchor at a new address still heals unverified. Refusals
originate at T1, so the hole closes only where the pair actually meets there. For `data-testid`
that is always, so the case this PR targets is fully closed. But:

```
baseline: getByRole('img').first()  anchor data-id=hero  fp aaa
current:  getByRole('img').nth(1)   anchor data-id=hero  fp bbb   <- different element
```

never meets at T1 and heals on the anchor. Signal for signal this is identical to the legitimate
"moved and churned" case, so no deterministic rule separates them, and gating anchor heals on
fingerprint agreement would close it by gutting the tier. Held open pending frequency data;
the proposed investigation is written up in the RFC.

## Open for review

One call made by judgment rather than instruction: excluding refused pairs from `likelyMoved` in
the engine rather than at each of the three render sites. The `report` drop-bug ships as a
drive-by here rather than as its own change.

No version bumps: releases are separate version-bump-only commits in this repo.
