### PR TITLE
Unify generated-id detection between core and heal-diff

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accesslint/core",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Pure accessibility rule engine — WCAG audit with zero browser dependencies",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/core/src/rules/utils/generated-id.test.ts
+++ b/core/src/rules/utils/generated-id.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { isGeneratedId, isStableId } from "./generated-id";
-import { getSelector, extractAnchor, clearSelectorCache } from "./selector";
+import {
+  getSelector,
+  extractAnchor,
+  buildRelativeLocation,
+  clearSelectorCache,
+} from "./selector";
 import { makeDoc } from "../../test-helpers";
 
 afterEach(() => clearSelectorCache());
@@ -56,5 +61,28 @@ describe("selector hardening", () => {
     const doc = makeDoc(`<button id=":r3:" name="save">x</button>`);
     const btn = doc.querySelector("button")!;
     expect(extractAnchor(btn)).toBe("name=save");
+  });
+
+  it("buildRelativeLocation ignores a generated id on the landmark", () => {
+    const build = (id: string) =>
+      buildRelativeLocation(
+        makeDoc(`<main id="${id}"><p>Email</p><button>x</button></main>`).querySelector("button")!,
+      );
+    expect(build("radix-:r1:")).toBe(build("radix-:r9:"));
+    expect(build("radix-:r1:")).not.toContain("radix");
+  });
+
+  it("buildRelativeLocation still uses an authored landmark id", () => {
+    const doc = makeDoc(`<main id="content"><p>Email</p><button>x</button></main>`);
+    expect(buildRelativeLocation(doc.querySelector("button")!)).toContain("main#content");
+  });
+
+  // A generated id must not win the intermediate-ancestor slot; the walk has to
+  // keep going and find the ancestor that actually carries stable identity.
+  it("buildRelativeLocation skips a generated-id ancestor for a role-bearing one", () => {
+    const doc = makeDoc(
+      `<main><div role="group"><div id=":r4:"><p>Email</p><button>x</button></div></div></main>`,
+    );
+    expect(buildRelativeLocation(doc.querySelector("button")!)).toContain("[role=group]");
   });
 });

--- a/core/src/rules/utils/generated-id.ts
+++ b/core/src/rules/utils/generated-id.ts
@@ -9,6 +9,11 @@
  * "generated".
  */
 
+// `@accesslint/heal-diff`'s normalize.ts carries an identical copy of this
+// list: both packages ship zero runtime dependencies, so it is duplicated
+// rather than imported. matchers-internal/src/generated-id-contract.test.ts
+// fails if the two drift. Change one, change the other, and bump heal-diff's
+// NORMALIZE_VERSION.
 const GENERATED_ID_PATTERNS: RegExp[] = [
   // React useId — `:r0:`, `:r1a:` (base-32 counter), and SSR `:R...:` form.
   /^:r[0-9a-z]+:$/i,

--- a/core/src/rules/utils/selector.ts
+++ b/core/src/rules/utils/selector.ts
@@ -229,7 +229,7 @@ function isLandmark(el: Element): boolean {
 
 function segmentFor(el: Element): string {
   const tag = el.tagName.toLowerCase();
-  if (el.id) return `${tag}#${el.id}`;
+  if (isStableId(el.id)) return `${tag}#${el.id}`;
   const role = el.getAttribute("role");
   return role ? `${tag}[role=${role}]` : tag;
 }
@@ -263,7 +263,7 @@ export function buildRelativeLocation(el: Element): string | null {
   const trail: string[] = [segmentFor(landmark)];
 
   for (const ancestor of between) {
-    if (ancestor.id || ancestor.getAttribute("role")) {
+    if (isStableId(ancestor.id) || ancestor.getAttribute("role")) {
       trail.push(segmentFor(ancestor));
       break;
     }

--- a/heal-diff/package.json
+++ b/heal-diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accesslint/heal-diff",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Multi-signal diff engine for baseline/current sets with tiered matching, auto-healing, and likely-moved detection.",
   "license": "MIT",
   "type": "module",

--- a/heal-diff/src/normalize.test.ts
+++ b/heal-diff/src/normalize.test.ts
@@ -45,6 +45,27 @@ describe("normalizeHtml", () => {
     expect(a).toBe(b);
   });
 
+  // These regenerate per mount, so leaving any of them in the digest gives the
+  // same unchanged element a fresh fingerprint on every audit run.
+  it.each([
+    [":r1a:", "React base-32 useId counter"],
+    [":R7:", "React SSR useId"],
+    ["radix-:r5:", "Radix UI"],
+    ["headlessui-menu-:r3:", "Headless UI"],
+    ["reach-dialog-1", "Reach UI"],
+    ["mui-123", "MUI"],
+    ["css-1ab2c3", "emotion"],
+    ["«1»", "MUI/emotion bracket form"],
+  ])("drops the %s id (%s)", (id) => {
+    expect(normalizeHtml(`<input id="${id}" type="text">`)).toBe(
+      normalizeHtml('<input type="text">'),
+    );
+  });
+
+  it("keeps authored ids", () => {
+    expect(normalizeHtml('<input id="email-field" type="text">')).toContain('id="email-field"');
+  });
+
   it("keeps semantic attributes like alt, href, aria-*", () => {
     const out = normalizeHtml('<a href="/x" aria-label="go">x</a>');
     expect(out).toContain('href="/x"');
@@ -111,7 +132,7 @@ describe("isFingerprintableTag", () => {
 
 describe("NORMALIZE_VERSION", () => {
   it("is exported and current", () => {
-    expect(NORMALIZE_VERSION).toBe(2);
+    expect(NORMALIZE_VERSION).toBe(3);
   });
 });
 

--- a/heal-diff/src/normalize.ts
+++ b/heal-diff/src/normalize.ts
@@ -16,8 +16,10 @@
  *
  * 1: attribute drop/sort, generated-id filtering, 64-char text truncation.
  * 2: adds URL query/fragment stripping on href/src values.
+ * 3: widens generated-id filtering to the full core pattern set (base-32
+ *    `useId` counters, MUI/emotion, Radix/Headless UI/Reach prefixes).
  */
-export const NORMALIZE_VERSION = 2;
+export const NORMALIZE_VERSION = 3;
 
 /** Attributes removed entirely during normalization. */
 const DROP_ATTRS = new Set(["class", "style"]);
@@ -26,14 +28,36 @@ const DROP_ATTRS = new Set(["class", "style"]);
  * stripped (cache busters, UTM params) so only the path identifies. */
 const URL_ATTRS = new Set(["href", "src"]);
 
-/** IDs matching these patterns are treated as generated and dropped. */
+/**
+ * IDs matching these patterns are treated as generated and dropped.
+ *
+ * Deliberately duplicated from `@accesslint/core`'s
+ * `rules/utils/generated-id.ts` rather than imported: both packages ship with
+ * zero runtime dependencies, and neither direction of the import is honest —
+ * a pure diff engine should not pull in the WCAG rule engine, and the rule
+ * engine should not depend on something downstream of it. The two copies are
+ * pinned together by the contract test in
+ * `matchers-internal/src/generated-id-contract.test.ts`, which is the one
+ * package that already depends on both. Change one, change the other, and
+ * bump NORMALIZE_VERSION.
+ */
 const GENERATED_ID_PATTERNS: RegExp[] = [
-  /^:r\d+:$/, // React useId
-  /^[a-f0-9]{8,}$/i, // long hex (emotion, uuid fragments)
-  /^[a-z0-9_-]+-[a-f0-9]{6,}$/i, // prefix + hash suffix
+  // React useId — `:r0:`, `:r1a:` (base-32 counter), and SSR `:R...:` form.
+  /^:r[0-9a-z]+:$/i,
+  // MUI / emotion auto ids — `«1»`, `mui-123`, `css-1ab2c3`.
+  /^«.+»$/,
+  /^mui-\d+$/,
+  /^css-[a-z0-9]+$/i,
+  // Radix / Headless UI / Reach UI prefixed ids — `radix-:r1:`, `headlessui-menu-:r3:`.
+  /^(radix|headlessui|reach)-/i,
+  // Long hex blobs (emotion class hashes, uuid fragments).
+  /^[a-f0-9]{8,}$/i,
+  // prefix + hash suffix — `field-9f3a1c`, `Tooltip-1a2b3c4`.
+  /^[a-z0-9_-]+-[a-f0-9]{6,}$/i,
 ];
 
-function isGeneratedId(value: string): boolean {
+/** True when `value` looks like a framework-generated id (unstable across runs). */
+export function isGeneratedId(value: string): boolean {
   return GENERATED_ID_PATTERNS.some((p) => p.test(value));
 }
 

--- a/matchers-internal/src/generated-id-contract.test.ts
+++ b/matchers-internal/src/generated-id-contract.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Contract: `@accesslint/core` and `@accesslint/heal-diff` must agree on what
+ * counts as a framework-generated id.
+ *
+ * The two packages carry duplicate copies of the pattern list (see the
+ * comments on each) because neither can depend on the other without dragging a
+ * zero-dependency published package into the other's tree. This is the test
+ * that makes the duplication safe, and it lives here because
+ * `matchers-internal` is the one package that already depends on both.
+ *
+ * When the lists drift, ids stay baked into the `htmlFingerprint` while core
+ * has already dropped them from the selector — the same unchanged element then
+ * fingerprints differently on every render, the address tier refuses its own
+ * match, and unchanged violations re-alert as new.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isGeneratedId as coreIsGeneratedId } from "@accesslint/core";
+import { isGeneratedId as healIsGeneratedId } from "@accesslint/heal-diff/normalize";
+
+/** One entry per pattern family in the list, plus authored ids that must survive. */
+const GENERATED = [
+  ":r0:",
+  ":r2:",
+  ":r1a:", // React base-32 useId counter — the drift that motivated this test
+  ":R7:", // SSR form
+  "«1»", // MUI/emotion bracket form
+  "mui-123",
+  "css-1ab2c3",
+  "radix-:r5:",
+  "headlessui-menu-:r3:",
+  "reach-dialog-1",
+  "a1b2c3d4", // long hex
+  "field-9f3a1c", // prefix + hash suffix
+];
+
+const AUTHORED = [
+  "submit",
+  "email-field",
+  "main-nav",
+  "user_profile",
+  "step1",
+  "checkout",
+  "newsletter-signup",
+];
+
+describe("generated-id contract between core and heal-diff", () => {
+  it.each(GENERATED)("both packages treat %s as generated", (id) => {
+    expect(coreIsGeneratedId(id)).toBe(true);
+    expect(healIsGeneratedId(id)).toBe(true);
+  });
+
+  it.each(AUTHORED)("both packages keep the authored id %s", (id) => {
+    expect(coreIsGeneratedId(id)).toBe(false);
+    expect(healIsGeneratedId(id)).toBe(false);
+  });
+
+  it("agrees across a broad generated-shaped sample", () => {
+    const sample = [
+      ...GENERATED,
+      ...AUTHORED,
+      ":r:",
+      ":rzz:",
+      "«»",
+      "mui-",
+      "muix-1",
+      "css-",
+      "radix",
+      "radixed-thing",
+      "headlessui",
+      "abc123",
+      "a1b2c3d",
+      "menu-abcdef",
+      "menu-abcde",
+      "",
+    ];
+    const disagreements = sample.filter((id) => coreIsGeneratedId(id) !== healIsGeneratedId(id));
+    expect(disagreements).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two independent regex lists both decide what counts as a framework-generated DOM id, and they had drifted. `core/src/rules/utils/generated-id.ts` carried seven patterns; `heal-diff/src/normalize.ts` carried three.

`normalizeHtml` strips volatile ids out of an element's HTML snippet before it is SHA-1'd into `htmlFingerprint`. Its narrower list missed React `useId` counters past `:r9:` (`^:r\d+:$` is digits-only, so `:r1a:` survived), the Radix / Headless UI / Reach prefixes, and the MUI/emotion forms:

| id | core.isGeneratedId | heal-diff stripped it |
| --- | --- | --- |
| `:r2:` | yes | yes |
| `:r1a:` | yes | **no** |
| `radix-:r5:` | yes | **no** |
| `mui-123` | yes | **no** |
| `«1»` | yes | **no** |
| `headlessui-menu-:r3:` | yes | **no** |

Any element carrying one of those, or capturing one on a descendant inside its 200-char snippet, kept a per-render value in the hashed string, so an unchanged element fingerprinted differently on every audit. Tier 1 is address plus fingerprint verification, so the match was refused and the violation fell through to weaker tiers, alerting as new when no stable anchor survived. Sites on shadcn/ui, Radix or MUI would hit this on every run.

## Approach

The list stays duplicated rather than imported. Both packages publish with zero runtime dependencies, and neither direction is honest: a pure diff engine should not pull in the WCAG rule engine, and the rule engine should not depend on something downstream of it. A contract test in `matchers-internal`, the one package that already depends on both, fails if they drift.

`NORMALIZE_VERSION` goes to 3. Stored fingerprints minted under the narrow list describe differently-normalized markup and are cold until their element is next seen and re-signed.

## Second fix

`segmentFor` and the intermediate-ancestor picker in `buildRelativeLocation` read `el.id` unconditionally, unlike `extractAnchor` and `buildSelectorWithinRoot` in the same file. A landmark carrying a generated id made `relativeLocation` regenerate per render, taking out the tier that exists to rescue a fingerprint-drifted violation.

## Verification

Regression fixtures live in accesslint.com (`apps/runner/test/agent/fixtures/selector_churn/`), covering base-32 `useId`, Radix, MUI and Headless UI. Confirmed as real tests: with the old three-pattern list all four drift both fingerprints; with the unified list all four are absorbed at the address tier.

Core (975 tests), heal-diff, and matchers-internal all pass. The `@accesslint/playwright` typecheck failure on this branch is pre-existing and unrelated: `playwright-core` does not resolve locally.