### PR TITLE
feat(source): audit JSX and TSX from a real parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ results/
 .env
 .turbo/
 .worktrees/
+scratch/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Accessibility testing tools for modern web development.
 | [`@accesslint/jest`](./jest)                       | Jest matchers — `toBeAccessible()`                | [![npm](https://img.shields.io/npm/v/@accesslint/jest)](https://www.npmjs.com/package/@accesslint/jest)                       |
 | [`@accesslint/mcp`](./mcp)                         | MCP server for AI-assisted accessibility auditing | [![npm](https://img.shields.io/npm/v/@accesslint/mcp)](https://www.npmjs.com/package/@accesslint/mcp)                         |
 | [`@accesslint/playwright`](./playwright)           | Playwright matchers — `toBeAccessible()`          | [![npm](https://img.shields.io/npm/v/@accesslint/playwright)](https://www.npmjs.com/package/@accesslint/playwright)           |
+| [`@accesslint/source`](./source)                   | Audit JSX/TSX component source without running it | [![npm](https://img.shields.io/npm/v/@accesslint/source)](https://www.npmjs.com/package/@accesslint/source)                   |
 | [`@accesslint/storybook-addon`](./storybook-addon) | Storybook addon for accessibility auditing        | [![npm](https://img.shields.io/npm/v/@accesslint/storybook-addon)](https://www.npmjs.com/package/@accesslint/storybook-addon) |
 | [`@accesslint/vitest`](./vitest)                   | Vitest matchers — `toBeAccessible()`              | [![npm](https://img.shields.io/npm/v/@accesslint/vitest)](https://www.npmjs.com/package/@accesslint/vitest)                   |
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -45,6 +45,14 @@ The turbo pipeline has three stages: `act:fixtures` (download + process), `act:t
 - `@accesslint/cli` has smoke tests for `audit.ts` and `inline-css.ts`. `ssrf-guard` and `safe-fetch` are covered transitively by `mcp/tests/security.test.ts` (which imports them directly from `@accesslint/cli/ssrf-guard` and `@accesslint/cli/safe-fetch`), so don't duplicate.
 - `@accesslint/mcp` has tests in `mcp/tests/` covering tools, security, and output formatting.
 
+## Source audits — `@accesslint/source`
+
+**Location:** `source/src/**/*.test.ts`
+**Runs via:** `bun run --filter=@accesslint/source test`
+**Environment:** Node with happy-dom installed by hand: `source/src/test-dom.ts` copies a shared `Window`'s properties onto `globalThis` and hands out fresh `Document`s, because the package's own API takes a `document` rather than assuming a global one.
+
+Three suites: `audit.test.ts` holds the worked cases and the corpus regressions (one named test per false-positive class found by hand-triage, under "what the corpus taught"); `jsx/render.test.ts` covers JSX-to-HTML rendering; `invariants.test.ts` states the zero-false-positive contract as properties over component shapes crossed with mutations that introduce unknowns. A new "source never guesses" behavior belongs in `audit.test.ts`; rule behavior still belongs in core.
+
 ## Quick reference
 
 | Task                                       | Command                                           |

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     },
     "jest": {
       "name": "@accesslint/jest",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@accesslint/core": "workspace:*",
       },
@@ -211,9 +211,24 @@
         "vitest": "^4.1.4",
       },
     },
+    "source": {
+      "name": "@accesslint/source",
+      "version": "0.1.0",
+      "dependencies": {
+        "@accesslint/core": "workspace:*",
+        "@babel/parser": "^7.26.0",
+      },
+      "devDependencies": {
+        "@babel/types": "^7.26.0",
+        "happy-dom": "^20.9.0",
+        "tsdown": "^0.21.9",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0",
+      },
+    },
     "storybook-addon": {
       "name": "@accesslint/storybook-addon",
-      "version": "0.8.12",
+      "version": "0.8.13",
       "dependencies": {
         "@accesslint/core": "workspace:*",
         "@accesslint/vitest": "workspace:*",
@@ -235,7 +250,7 @@
     },
     "vitest": {
       "name": "@accesslint/vitest",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@accesslint/core": "workspace:*",
       },
@@ -273,6 +288,8 @@
     "@accesslint/playwright": ["@accesslint/playwright@workspace:playwright"],
 
     "@accesslint/report": ["@accesslint/report@workspace:report"],
+
+    "@accesslint/source": ["@accesslint/source@workspace:source"],
 
     "@accesslint/storybook-addon": ["@accesslint/storybook-addon@workspace:storybook-addon"],
 
@@ -318,9 +335,9 @@
 
     "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.3", "", {}, "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.3", "", {}, "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
 
@@ -390,7 +407,7 @@
 
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
-    "@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
@@ -1756,6 +1773,8 @@
 
     "@accesslint/mcp/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
+    "@accesslint/source/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
     "@accesslint/storybook-addon/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "@accesslint/storybook-addon/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
@@ -1766,19 +1785,15 @@
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
-
-    "@babel/core/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/generator/@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
-    "@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+    "@babel/generator/@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -1786,25 +1801,7 @@
 
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/helper-member-expression-to-functions/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@babel/helper-module-imports/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/helper-optimise-call-expression/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@babel/helpers/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@babel/template/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
     "@babel/traverse/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
-
-    "@babel/traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1832,14 +1829,6 @@
 
     "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
-    "@types/babel__core/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@types/babel__generator/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@types/babel__template/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@types/babel__traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -1857,8 +1846,6 @@
     "ast-kit/@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
-
-    "babel-plugin-jest-hoist/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "chrome-remote-interface/commander": ["commander@2.11.0", "", {}, "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="],
 
@@ -1888,8 +1875,6 @@
 
     "jest-snapshot/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
 
-    "jest-snapshot/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "jest-watcher/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
@@ -1901,8 +1886,6 @@
     "jsdom/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "magicast/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "make-dir/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
@@ -1920,7 +1903,11 @@
 
     "resolve-cwd/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
+    "rolldown-plugin-dts/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.3", "", {}, "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw=="],
+
     "rolldown-plugin-dts/@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
+
+    "rolldown-plugin-dts/@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -2012,6 +1999,26 @@
 
     "@accesslint/mcp/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
+    "@accesslint/source/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@accesslint/source/vitest/@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@accesslint/source/vitest/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@accesslint/source/vitest/@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@accesslint/source/vitest/@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@accesslint/source/vitest/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@accesslint/source/vitest/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@accesslint/source/vitest/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@accesslint/source/vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "@accesslint/source/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
     "@accesslint/storybook-addon/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "@accesslint/vitest/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
@@ -2034,45 +2041,9 @@
 
     "@accesslint/vitest/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
-    "@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+    "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.3", "", {}, "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA=="],
 
-    "@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/helper-annotate-as-pure/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-annotate-as-pure/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/helper-member-expression-to-functions/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-member-expression-to-functions/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-module-imports/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/helper-optimise-call-expression/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-optimise-call-expression/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/helpers/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helpers/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.3", "", {}, "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -2090,31 +2061,13 @@
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "@types/babel__core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@types/babel__core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@types/babel__generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@types/babel__generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@types/babel__template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@types/babel__template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@types/babel__traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
+
     "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "babel-plugin-jest-hoist/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "babel-plugin-jest-hoist/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
@@ -2146,17 +2099,11 @@
 
     "jest-environment-jsdom/jsdom/xml-name-validator": ["xml-name-validator@4.0.0", "", {}, "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="],
 
-    "jest-snapshot/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "jest-snapshot/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
     "jest-watcher/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
-    "magicast/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "magicast/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "rolldown-plugin-dts/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.3", "", {}, "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA=="],
 
     "storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
@@ -2217,6 +2164,10 @@
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.3", "", {}, "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA=="],
+
+    "ast-kit/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.3", "", {}, "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw=="],
 
     "find-cache-dir/pkg-dir/find-up/locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 

--- a/core/src/rules/labels-and-names/label-content-mismatch.test.ts
+++ b/core/src/rules/labels-and-names/label-content-mismatch.test.ts
@@ -122,4 +122,23 @@ describe(RULE_ID, () => {
       '<button aria-label="Close"><svg aria-hidden="true"></svg></button>',
     );
   });
+
+  it("accepts a lone significant word next to a decorative glyph", () => {
+    expectNoViolations(
+      labelContentMismatch,
+      `
+      <a href="/deploy" aria-label="Deploy on Vercel">
+        <span>▲</span>
+        <span>Deploy</span>
+      </a>
+    `,
+    );
+  });
+
+  it("still reports a lone word the name does not contain", () => {
+    expectViolations(labelContentMismatch, '<button aria-label="Save changes">Cancel</button>', {
+      count: 1,
+      ruleId: RULE_ID,
+    });
+  });
 });

--- a/core/src/rules/labels-and-names/label-content-mismatch.ts
+++ b/core/src/rules/labels-and-names/label-content-mismatch.ts
@@ -23,12 +23,18 @@ function visibleTextMatches(accessibleName: string, visibleText: string): boolea
   // Accept if most significant words of the visible text appear in the
   // accessible name.  This handles cases like "Parks By State" (aria-label)
   // vs "By State..." (visible text after icons/prefixes are stripped).
-  // Strip trailing punctuation from words before comparing.
+  //
+  // Decorative characters are stripped from both ends of each word, and a single
+  // significant word counts. `<a aria-label="Deploy on Vercel"><span>\u25b2</span>
+  // <span>Deploy</span></a>` reads as a mismatch otherwise: adjacent spans
+  // contribute no whitespace, so the glyph arrives glued to the word as
+  // "\u25b2Deploy", while the label a voice-control user speaks \u2014 "Deploy" \u2014 is in
+  // the name.
   const visibleWords = normVisible
     .split(/\s+/)
-    .map((w) => w.replace(/[.,;:!?\u2026]+$/g, ""))
+    .map((w) => w.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ""))
     .filter((w) => w.length > 2);
-  if (visibleWords.length >= 2) {
+  if (visibleWords.length >= 1) {
     const matchingWords = visibleWords.filter((w) => normAccessible.includes(w));
     if (matchingWords.length / visibleWords.length > 0.5) return true;
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mcp",
     "playwright",
     "report",
+    "source",
     "storybook-addon",
     "vitest"
   ],

--- a/source/README.md
+++ b/source/README.md
@@ -77,8 +77,16 @@ Rendering-dependent rules (contrast, spacing, focus visibility) and cross-elemen
 `idref` rules are off in source mode. `SOURCE_MODE_DISABLED_RULES` is exported if
 you want to see the list.
 
+Two kinds of file are skipped outright, both because a finding in one could not be
+a defect a user hits: JSX rendered by something that is not a DOM (satori,
+`@vercel/og`, Next's image modules), and test files and fixtures, whose markup is
+written to be wrong. `includeTestFiles` turns the second one back on.
+
 ## Coverage today
 
-JSX and TSX. Vue and Svelte map onto the same semantics and are next; the
-per-dialect gate is a hand-triaged run over real repositories at zero confirmed
-false positives.
+JSX and TSX, measured against ten popular React repositories — 12,557 files, 109
+findings, zero confirmed false positives after hand-triaging every one. What the
+first run got wrong lives on as the "what the corpus taught" tests in
+`src/audit.test.ts`.
+
+Vue and Svelte map onto the same semantics and are next, each behind the same gate.

--- a/source/README.md
+++ b/source/README.md
@@ -1,0 +1,84 @@
+# @accesslint/source
+
+Audit component **source** for accessibility. Parses a JSX/TSX file, renders its
+intrinsic elements as HTML, and runs [`@accesslint/core`](../core) over the
+result — so a finding comes back with the rule, the message, and the line in the
+file you wrote.
+
+No bundler, no dev server, no rendering, and no execution of the code being
+audited. Point it at a file and it answers.
+
+## The contract
+
+**What the source does not pin down produces silence, not a guess.** A finding
+this package returns is a defect at runtime whatever the unknowns turn out to be.
+Everything else comes back as a _candidate_ — the violation the engine reported,
+plus the unknown that stopped it from being a finding.
+
+That split is the point. Findings are safe to post as review comments on a
+protected branch. Candidates are input for a later layer that can go get the
+missing evidence (the component's own definition, the spread's source) and decide.
+
+False negatives are the accepted price.
+
+## Usage
+
+```ts
+import { auditSource } from "@accesslint/source";
+import { Window } from "happy-dom";
+
+const window = new Window();
+for (const key of Object.getOwnPropertyNames(window)) {
+  if (!globalThis[key]) globalThis[key] = window[key];
+}
+globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+
+const { findings, candidates } = auditSource({
+  source: await readFile("Avatar.tsx", "utf8"),
+  filename: "Avatar.tsx",
+  document: window.document,
+});
+
+for (const finding of findings) {
+  console.log(`${finding.file}:${finding.line} ${finding.ruleId} — ${finding.message}`);
+}
+```
+
+The DOM is yours to provide: happy-dom, jsdom, or a real browser, along with the
+globals the engine's rules read (`getComputedStyle`, the element constructors).
+The package brings no DOM of its own.
+
+`renderJsx` is exported too, for looking at the synthetic HTML directly.
+
+## What it can and cannot see
+
+| The source says                        | The audit reads it as                                                        |
+| -------------------------------------- | ---------------------------------------------------------------------------- |
+| `<img src="/a.png" />`                 | an intrinsic element, fully audited                                          |
+| `<img src={url} />`                    | `src` present with an unknown value; a missing `alt` here is still a finding |
+| `<img {...props} />`                   | absence unprovable — every missing-attribute finding becomes a candidate     |
+| `<img {...props} alt="" />`            | `alt` provably empty: nothing after a spread can override it                 |
+| `<img alt="" {...props} />`            | `alt` unknown: the spread can override it                                    |
+| `<Button>…</Button>`                   | the component vanishes, its children are audited in place                    |
+| `<ul><MenuItem /></ul>`                | the list's contents are unknown — container rules go quiet                   |
+| `<ul>{items.map((i) => <div />)}</ul>` | the `<div>` is real, and reported                                            |
+| `<h1>{title}</h1>`                     | a stand-in name, so "empty heading" is not claimed                           |
+| `{cond ? <a /> : <b />}`               | both arms, so document-order rules go quiet for the file                     |
+| `style={{ display: "none" }}`          | hidden, exactly as at runtime                                                |
+| `aria-hidden={flag}`                   | may not be in the accessibility tree: the subtree goes quiet                 |
+| a file that does not parse             | no findings at all                                                           |
+
+Every file is treated as a component, so page-level rules never run — with one
+exception: a file containing a literal `<html>` tag (a Next.js root layout, a
+Remix root) is asked whether it set `lang`, because all of that evidence is in
+the one tag.
+
+Rendering-dependent rules (contrast, spacing, focus visibility) and cross-element
+`idref` rules are off in source mode. `SOURCE_MODE_DISABLED_RULES` is exported if
+you want to see the list.
+
+## Coverage today
+
+JSX and TSX. Vue and Svelte map onto the same semantics and are next; the
+per-dialect gate is a hand-triaged run over real repositories at zero confirmed
+false positives.

--- a/source/jsx.d.ts
+++ b/source/jsx.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/jsx/index";

--- a/source/package.json
+++ b/source/package.json
@@ -16,8 +16,12 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist/**/*",
+    "*.d.ts"
   ],
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/source/package.json
+++ b/source/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@accesslint/source",
+  "version": "0.1.0",
+  "description": "Audit component source (JSX/TSX) for accessibility from a real parse — synthetic HTML into @accesslint/core, with source lines and no guesses.",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AccessLint/accesslint.git",
+    "directory": "source"
+  },
+  "bugs": {
+    "url": "https://github.com/AccessLint/accesslint/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./jsx": {
+      "import": {
+        "types": "./dist/jsx/index.d.ts",
+        "default": "./dist/jsx/index.js"
+      },
+      "require": {
+        "types": "./dist/jsx/index.d.cts",
+        "default": "./dist/jsx/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
+  },
+  "dependencies": {
+    "@accesslint/core": "workspace:*",
+    "@babel/parser": "^7.26.0"
+  },
+  "devDependencies": {
+    "@babel/types": "^7.26.0",
+    "happy-dom": "^20.9.0",
+    "tsdown": "^0.21.9",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "keywords": [
+    "accessibility",
+    "a11y",
+    "wcag",
+    "jsx",
+    "tsx",
+    "react",
+    "static-analysis",
+    "accesslint"
+  ]
+}

--- a/source/src/audit.test.ts
+++ b/source/src/audit.test.ts
@@ -110,6 +110,12 @@ describe("components and spreads", () => {
     const candidate = result.candidates.find((c) => c.ruleId === "keyboard-accessible/tabindex");
     expect(candidate?.unknown.kind).toBe("spread");
   });
+
+  it("treats an empty alt after a spread as provably empty, not unknown", () => {
+    const result = audit(`export const Icon = (props) => <img {...props} alt="" />;`);
+    expect(ruleIds(result)).not.toContain("text-alternatives/img-alt");
+    expect(candidateIds(result)).not.toContain("text-alternatives/img-alt");
+  });
 });
 
 describe("expressions", () => {

--- a/source/src/audit.test.ts
+++ b/source/src/audit.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import { auditSource } from "./audit";
+import { testDocument } from "./test-dom";
+import type { SourceAuditResult } from "./types";
+
+function audit(source: string, filename = "Component.tsx"): SourceAuditResult {
+  return auditSource({ source, filename, document: testDocument() });
+}
+
+function ruleIds(result: SourceAuditResult): string[] {
+  return result.findings.map((finding) => finding.ruleId);
+}
+
+function candidateIds(result: SourceAuditResult): string[] {
+  return result.candidates.map((candidate) => candidate.ruleId);
+}
+
+describe("the cases the extensions were removed over", () => {
+  it("reports a missing alt on an image whose src is an expression", () => {
+    const result = audit(`
+      export function Avatar({ user }) {
+        return <img src={user.avatarUrl} />;
+      }
+    `);
+
+    expect(ruleIds(result)).toContain("text-alternatives/img-alt");
+    const finding = result.findings.find((f) => f.ruleId === "text-alternatives/img-alt");
+    expect(finding?.line).toBe(3);
+    expect(finding?.file).toBe("Component.tsx");
+    expect(finding?.html).not.toContain("data-accesslint-node");
+  });
+
+  it("does not read an expression in a list as text content", () => {
+    const result = audit(`
+      export function List({ items }) {
+        return <ul>{renderItems(items)}</ul>;
+      }
+    `);
+
+    expect(ruleIds(result)).not.toContain("adaptable/list-children");
+  });
+
+  it("reports a non-li element mapped into a list", () => {
+    const result = audit(`
+      export function List({ items }) {
+        return (
+          <ul>
+            {items.map((item) => (
+              <div key={item.id}>{item.label}</div>
+            ))}
+          </ul>
+        );
+      }
+    `);
+
+    expect(ruleIds(result)).toContain("adaptable/list-children");
+    const finding = result.findings.find((f) => f.ruleId === "adaptable/list-children");
+    expect(finding?.line).toBe(6);
+  });
+});
+
+describe("components and spreads", () => {
+  it("keeps intrinsic islands inside a component auditable", () => {
+    const result = audit(`
+      export const Hero = () => (
+        <Card>
+          <img src="/hero.png" />
+        </Card>
+      );
+    `);
+
+    expect(ruleIds(result)).toContain("text-alternatives/img-alt");
+  });
+
+  it("suppresses a container finding when a child is a component", () => {
+    const result = audit(`
+      export const Menu = () => (
+        <ul>
+          <MenuItem />
+          <div>Static</div>
+        </ul>
+      );
+    `);
+
+    expect(ruleIds(result)).not.toContain("adaptable/list-children");
+    expect(candidateIds(result)).toContain("adaptable/list-children");
+    const candidate = result.candidates.find((c) => c.ruleId === "adaptable/list-children");
+    expect(candidate?.unknown.kind).toBe("component-child");
+  });
+
+  it("suppresses a missing attribute on an element carrying a spread", () => {
+    const result = audit(`
+      export const Icon = (props) => <img {...props} />;
+    `);
+
+    expect(result.findings).toEqual([]);
+    expect(candidateIds(result)).toContain("text-alternatives/img-alt");
+    expect(result.candidates[0]?.unknown.kind).toBe("spread");
+    expect(result.candidates[0]?.unknown.expression).toBe("props");
+  });
+
+  it("reports a value written after the spread, which nothing can override", () => {
+    const result = audit(`export const Row = (props) => <div {...props} tabIndex={5} />;`);
+    expect(ruleIds(result)).toContain("keyboard-accessible/tabindex");
+  });
+
+  it("suppresses the same value written before the spread", () => {
+    const result = audit(`export const Row = (props) => <div tabIndex={5} {...props} />;`);
+    expect(ruleIds(result)).not.toContain("keyboard-accessible/tabindex");
+    const candidate = result.candidates.find((c) => c.ruleId === "keyboard-accessible/tabindex");
+    expect(candidate?.unknown.kind).toBe("spread");
+  });
+});
+
+describe("expressions", () => {
+  it("treats a false-valued attribute as provably absent", () => {
+    const result = audit(`export const A = () => <img src="/a.png" alt={undefined} />;`);
+    expect(ruleIds(result)).toContain("text-alternatives/img-alt");
+  });
+
+  it("treats an expression-valued alt as present but unknown", () => {
+    const result = audit(`export const A = ({ alt }) => <img src="/a.png" alt={alt} />;`);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("stands in for an expression in text position", () => {
+    const result = audit(`export const H = ({ title }) => <h2>{title}</h2>;`);
+    expect(ruleIds(result)).not.toContain("navigable/empty-heading");
+  });
+
+  it("reports a heading that is empty in both arms of a conditional", () => {
+    const result = audit(`
+      export const H = ({ big }) => (big ? <h1></h1> : <h2></h2>);
+    `);
+    expect(ruleIds(result).filter((id) => id === "navigable/empty-heading")).toHaveLength(2);
+  });
+
+  it("silences heading order across two components in one file", () => {
+    const result = audit(`
+      export const Title = () => <h1>Title</h1>;
+      export const Section = () => <h3>Section</h3>;
+    `);
+    expect(ruleIds(result)).not.toContain("navigable/heading-order");
+    const candidate = result.candidates.find((c) => c.ruleId === "navigable/heading-order");
+    expect(candidate?.unknown.kind).toBe("exclusive-branches");
+  });
+
+  it("silences heading order once the file emits exclusive branches", () => {
+    const result = audit(`
+      export const H = ({ big }) => (
+        <div>
+          <h1>Title</h1>
+          {big ? <h4>Big</h4> : <h2>Small</h2>}
+        </div>
+      );
+    `);
+    expect(ruleIds(result)).not.toContain("navigable/heading-order");
+  });
+
+  it("says nothing about a component whose name comes from elsewhere", () => {
+    const result = audit(`
+      export const Dialog = () => <button aria-labelledby="dialog-title" />;
+    `);
+    expect(result.findings).toEqual([]);
+    expect(result.candidates[0]?.unknown.kind).toBe("external-idref");
+  });
+
+  it("resolves a literal style object so a hidden element stays hidden", () => {
+    const result = audit(`
+      export const A = () => <img src="/a.png" style={{ display: "none" }} />;
+    `);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("suppresses everything under an element whose hiding is unknown", () => {
+    const result = audit(`
+      export const A = ({ hidden }) => (
+        <div aria-hidden={hidden}>
+          <img src="/a.png" />
+        </div>
+      );
+    `);
+    expect(result.findings).toEqual([]);
+    expect(result.candidates[0]?.unknown.kind).toBe("unknown-semantics");
+  });
+});
+
+describe("page-level questions", () => {
+  it("asks for lang on a literal html element", () => {
+    const result = audit(
+      `
+      export default function Layout({ children }) {
+        return (
+          <html>
+            <body>{children}</body>
+          </html>
+        );
+      }
+    `,
+      "layout.tsx",
+    );
+
+    expect(ruleIds(result)).toContain("readable/html-has-lang");
+    expect(result.findings[0]?.line).toBe(4);
+  });
+
+  it("stays quiet when lang is set from an expression", () => {
+    const result = audit(
+      `
+      export default function Layout({ locale, children }) {
+        return (
+          <html lang={locale}>
+            <body>{children}</body>
+          </html>
+        );
+      }
+    `,
+      "layout.tsx",
+    );
+
+    expect(ruleIds(result)).not.toContain("readable/html-has-lang");
+  });
+
+  it("never asks a page-level question of a component", () => {
+    const result = audit(`export const A = () => <div>Hello</div>;`);
+    expect(ruleIds(result)).not.toContain("navigable/document-title");
+    expect(ruleIds(result)).not.toContain("landmarks/landmark-main");
+    expect(ruleIds(result)).not.toContain("readable/html-has-lang");
+  });
+});
+
+describe("parsing", () => {
+  it("returns nothing for a file it cannot parse", () => {
+    const result = audit(`export const A = () => <div>;`);
+    expect(result.parsed).toBe(false);
+    expect(result.findings).toEqual([]);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it("reads TypeScript-only syntax", () => {
+    const result = audit(`
+      interface Props { src: string }
+      export const A = ({ src }: Props) => <img src={src} />;
+    `);
+    expect(result.parsed).toBe(true);
+    expect(ruleIds(result)).toContain("text-alternatives/img-alt");
+  });
+
+  it("reads a .jsx file with a type-parameter-shaped expression", () => {
+    const result = audit(`export const A = () => <img src="/a.png" />;`, "Component.jsx");
+    expect(result.dialect).toBe("jsx");
+    expect(ruleIds(result)).toContain("text-alternatives/img-alt");
+  });
+});

--- a/source/src/audit.test.ts
+++ b/source/src/audit.test.ts
@@ -135,14 +135,27 @@ describe("expressions", () => {
     expect(ruleIds(result).filter((id) => id === "navigable/empty-heading")).toHaveLength(2);
   });
 
-  it("silences heading order across two components in one file", () => {
+  it("never compares two components in one file", () => {
+    // Each root is audited in its own document, so an <h1> here and an <h3>
+    // there is not a heading order and the question never comes up.
     const result = audit(`
       export const Title = () => <h1>Title</h1>;
       export const Section = () => <h3>Section</h3>;
     `);
     expect(ruleIds(result)).not.toContain("navigable/heading-order");
-    const candidate = result.candidates.find((c) => c.ruleId === "navigable/heading-order");
-    expect(candidate?.unknown.kind).toBe("exclusive-branches");
+    expect(candidateIds(result)).not.toContain("navigable/heading-order");
+  });
+
+  it("reports a heading order defect inside one component", () => {
+    const result = audit(`
+      export const Page = () => (
+        <div>
+          <h1>Title</h1>
+          <h3>Section</h3>
+        </div>
+      );
+    `);
+    expect(ruleIds(result)).toContain("navigable/heading-order");
   });
 
   it("silences heading order once the file emits exclusive branches", () => {
@@ -226,6 +239,253 @@ describe("page-level questions", () => {
     expect(ruleIds(result)).not.toContain("navigable/document-title");
     expect(ruleIds(result)).not.toContain("landmarks/landmark-main");
     expect(ruleIds(result)).not.toContain("readable/html-has-lang");
+  });
+});
+
+// Every case in this block is a false positive the corpus run found: a real repo,
+// a finding a human triager called wrong, and the reason it was wrong.
+describe("what the corpus taught", () => {
+  it("names a button from text anywhere in its subtree", () => {
+    // supabase ContextMenu.tsx: the label is one level down, so the button's own
+    // children were both known and the name looked missing.
+    const result = audit(`
+      export const Item = ({ item }) => (
+        <button type="button">
+          <div className="label">{item.label}</div>
+        </button>
+      );
+    `);
+    expect(ruleIds(result)).not.toContain("labels-and-names/button-name");
+  });
+
+  it("still reports an icon-only button with nothing to name it", () => {
+    const result = audit(`
+      export const Close = () => (
+        <button type="button">
+          <svg viewBox="0 0 24 24" />
+        </button>
+      );
+    `);
+    expect(ruleIds(result)).toContain("labels-and-names/button-name");
+  });
+
+  it("keeps container integrity one level deep", () => {
+    // The div's own contents being unknown says nothing about where the div sits.
+    const result = audit(`
+      export const List = ({ items }) => (
+        <ul>
+          {items.map((item) => (
+            <div key={item.id}>{item.label}</div>
+          ))}
+        </ul>
+      );
+    `);
+    expect(ruleIds(result)).toContain("adaptable/list-children");
+  });
+
+  it("says nothing about a list whose text came from a component", () => {
+    // supabase LWSummary.tsx: <ol><Link>…</Link></ol> renders an <a> child, not
+    // the bare text the engine saw.
+    const result = audit(`
+      export const Days = () => (
+        <ol className="border-t">
+          <Link href="/a">Open Source Hackathon</Link>
+        </ol>
+      );
+    `);
+    expect(result.findings).toEqual([]);
+    const candidate = result.candidates.find((c) => c.ruleId === "adaptable/list-children");
+    expect(candidate?.unknown.kind).toBe("component-child");
+  });
+
+  it("says nothing about a table whose rows are components", () => {
+    const result = audit(`
+      export const Pricing = ({ plans }) => (
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Feature</th>
+            </tr>
+          </thead>
+          <tbody>
+            <PricingRow plans={plans} />
+          </tbody>
+        </table>
+      );
+    `);
+    expect(ruleIds(result)).not.toContain("adaptable/th-has-data-cells");
+  });
+
+  it("treats a hiding utility class as a hiding it cannot rule out", () => {
+    const result = audit(`
+      export const Submit = () => <button type="submit" className="hidden" tabIndex={-1} />;
+    `);
+    expect(result.findings).toEqual([]);
+    expect(result.candidates[0]?.unknown.kind).toBe("unknown-semantics");
+  });
+
+  it("audits a column that a breakpoint shows again", () => {
+    // shadcn's login blocks: `hidden lg:block` is a responsive column, not a
+    // hidden one, and the alt text inside it is read by anyone on a laptop.
+    const result = audit(`
+      export const Login = () => (
+        <div className="relative hidden bg-muted lg:block">
+          <img src="/placeholder.svg" alt="Image" className="absolute inset-0" />
+        </div>
+      );
+    `);
+    expect(ruleIds(result)).toContain("text-alternatives/image-alt-words");
+  });
+
+  it("says nothing about JSX that renders to an image, not a document", () => {
+    const result = audit(
+      `
+      import { ImageResponse } from "next/og";
+
+      export default function OG() {
+        return new ImageResponse(
+          <div style={{ display: "flex" }}>
+            <img src={logo} width="200" height="200" />
+          </div>,
+        );
+      }
+    `,
+      "route.tsx",
+    );
+    expect(result.skipped).toBe("non-dom-renderer");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("recognizes a satori component file by its tw prop", () => {
+    const result = audit(`
+      export const Card = ({ logo }) => (
+        <div tw="flex items-center">
+          <img src={logo} width="90px" height="90px" tw="mr-6" />
+        </div>
+      );
+    `);
+    expect(result.skipped).toBe("non-dom-renderer");
+  });
+
+  it("leaves test fixtures alone unless asked", () => {
+    const source = `export const Fixture = () => <button type="button" tabIndex={3} />;`;
+    expect(audit(source, "FocusTrap.test.tsx").skipped).toBe("test-file");
+    expect(audit(source, "test/fixtures/FocusTrap.tsx").skipped).toBe("test-file");
+    const included = auditSource({
+      source,
+      filename: "FocusTrap.test.tsx",
+      document: testDocument(),
+      includeTestFiles: true,
+    });
+    expect(included.skipped).toBeUndefined();
+    expect(included.findings.map((f) => f.ruleId)).toContain("keyboard-accessible/tabindex");
+  });
+
+  it("keeps a table fragment's own structure, and asks nothing of the table around it", () => {
+    // A component that renders one row is dropped outright by an HTML parser
+    // unless it is wrapped, and everything after it in the document gets
+    // rearranged. Wrapped, the row survives — and no rule may then reason about
+    // the table we invented to hold it.
+    const result = audit(`
+      export const Row = ({ name }) => (
+        <tr>
+          <td>{name}</td>
+          <td>
+            <button type="button" />
+          </td>
+        </tr>
+      );
+    `);
+    expect(result.html).toContain("<tr");
+    expect(result.html).toContain("<button");
+    expect(ruleIds(result)).toContain("labels-and-names/button-name");
+    expect(ruleIds(result)).not.toContain("adaptable/td-has-header");
+  });
+
+  it("puts each finding on its own line when two elements look alike", () => {
+    // supabase launch-week: two <a href={expr}> both render href="unknown", so
+    // both got the same CSS selector and every finding landed on the first one.
+    const result = audit(`
+      export const Links = ({ blog, docs }) => (
+        <div>
+          <a href={blog}>
+            <img src="/blog.svg" />
+          </a>
+          {docs && (
+            <a href={docs}>
+              <img src="/docs.svg" />
+            </a>
+          )}
+        </div>
+      );
+    `);
+    const lines = result.findings
+      .filter((finding) => finding.ruleId === "text-alternatives/img-alt")
+      .map((finding) => finding.line);
+    expect(lines).toEqual([5, 9]);
+  });
+
+  it("leaves a component in a table unexpanded", () => {
+    // docusaurus style-isolation: <tbody><ExampleRow><h1>title</h1></ExampleRow>
+    // renders a row at runtime. Emitting the h1 in the row's place put it inside
+    // <tbody>, where the parser foster-parents element and text out separately —
+    // which reported an empty <h1>, an empty <button>, and a nameless link, none
+    // of them true.
+    const result = audit(`
+      export default function Page() {
+        return (
+          <table>
+            <tbody>
+              <ExampleRow name="h1">
+                <h1>title</h1>
+              </ExampleRow>
+              <ExampleRow name="a">
+                <a href="https://example.com">link</a>
+              </ExampleRow>
+            </tbody>
+          </table>
+        );
+      }
+    `);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("does not let one root rearrange another", () => {
+    // The docusaurus style-isolation page: a row-rendering component sits above a
+    // page component, and concatenating them flattened every element after the
+    // row, which reported an empty <h1>, an empty <button> and a nameless link.
+    const result = audit(`
+      const Row = ({ name, children }) => (
+        <tr>
+          <td>{name}</td>
+          <td>{children}</td>
+        </tr>
+      );
+
+      export default function Page() {
+        return (
+          <div>
+            <h1>Heading</h1>
+            <a href="https://example.com">link</a>
+            <button>button</button>
+          </div>
+        );
+      }
+    `);
+    expect(ruleIds(result)).not.toContain("navigable/empty-heading");
+    expect(ruleIds(result)).not.toContain("navigable/link-name");
+    expect(ruleIds(result)).not.toContain("labels-and-names/button-name");
+  });
+
+  it("never asks whether a div with tabindex is a scroll container", () => {
+    const result = audit(`
+      export const Scroller = () => (
+        <div tabIndex={0} style={{ overflowY: "auto", height: "600px" }}>
+          <p>Content</p>
+        </div>
+      );
+    `);
+    expect(ruleIds(result)).not.toContain("keyboard-accessible/focus-order");
   });
 });
 

--- a/source/src/audit.ts
+++ b/source/src/audit.ts
@@ -87,7 +87,7 @@ export function auditSource(options: AuditSourceOptions): SourceAuditResult {
     }
 
     for (const violation of violations) {
-      const element = locate(doc, violation, installed);
+      const element = locate(violation, installed);
       if (!element) continue;
 
       const own = metaByElement.get(element);
@@ -109,7 +109,7 @@ export function auditSource(options: AuditSourceOptions): SourceAuditResult {
         file: options.filename,
       };
 
-      const unknown = unprovable(violation, element, own ?? anchor, doc, metaByElement, tree);
+      const unknown = unprovable(violation, element, own ?? anchor, installed);
       if (unknown) candidates.push({ ...finding, unknown });
       else findings.push(finding);
     }
@@ -137,6 +137,8 @@ function byPosition(a: SourceFinding, b: SourceFinding): number {
 }
 
 interface Installed {
+  doc: Document;
+  tree: SourceTree;
   metaByElement: Map<Element, NodeMeta>;
   elementByIndex: Map<number, Element>;
 }
@@ -187,7 +189,7 @@ function install(doc: Document, tree: SourceTree, nodes: NodeMeta[]): Installed 
     for (const child of element.children) visit(child);
   };
   visit(root);
-  return { metaByElement, elementByIndex };
+  return { doc, tree, metaByElement, elementByIndex };
 }
 
 /** The marker as it appears at the front of an element's own HTML snippet. */
@@ -204,7 +206,7 @@ function clean(text: string): string {
  * quotes is the element's own HTML, so the marker in it is proof of identity,
  * where a selector is only a guess that happens to be unique most of the time.
  */
-function locate(doc: Document, violation: Violation, installed: Installed): Element | null {
+function locate(violation: Violation, installed: Installed): Element | null {
   const marked = MARKED_SNIPPET.exec(violation.html);
   if (marked) {
     const element = installed.elementByIndex.get(Number(marked[1]));
@@ -212,7 +214,7 @@ function locate(doc: Document, violation: Violation, installed: Installed): Elem
   }
   if (violation.element) return violation.element;
   try {
-    return doc.querySelector(violation.selector);
+    return installed.doc.querySelector(violation.selector);
   } catch {
     return null;
   }
@@ -307,10 +309,9 @@ function unprovable(
   violation: Violation,
   element: Element,
   meta: NodeMeta,
-  doc: Document,
-  metaByElement: Map<Element, NodeMeta>,
-  tree: SourceTree,
+  installed: Installed,
 ): SourceUnknown | null {
+  const { doc, tree, metaByElement } = installed;
   // An element whose own hiding is unknown may not be in the accessibility tree
   // at all, and neither may anything under it.
   for (let node: Element | null = element; node; node = node.parentElement) {

--- a/source/src/audit.ts
+++ b/source/src/audit.ts
@@ -2,12 +2,14 @@ import { clearAllCaches, getRuleById, runAudit, type AuditOptions } from "@acces
 import type { Violation } from "@accesslint/core";
 import { MARKER_ATTRIBUTE, type NodeMeta } from "./emit";
 import { renderJsx } from "./jsx";
-import type { SourceRender } from "./render";
+import { wrapped, type SourceTree } from "./render";
+import { nonDomRenderer, testFile } from "./scope";
 import {
   attributeDependencies,
   CHILD_DEPENDENT_RULES,
   CONTAINER_MEMBER_RULES,
   DEPENDS_ON_ANY_UNKNOWN,
+  DIRECT_CHILD_RULES,
   DOC_ORDER_DEPENDENT_RULES,
   FRAGMENT_DISABLED_RULES,
   HTML_ELEMENT_RULE,
@@ -40,14 +42,16 @@ export function detectDialect(filename?: string): Dialect | null {
 export function auditSource(options: AuditSourceOptions): SourceAuditResult {
   // No filename and no dialect: parse as TSX, the superset that also reads JSX.
   const dialect = options.dialect ?? detectDialect(options.filename) ?? "tsx";
+
+  const skipped = outOfScope(options);
+  if (skipped) {
+    return { findings: [], candidates: [], dialect, parsed: true, html: "", skipped };
+  }
+
   const render = renderJsx(options.source, { typescript: dialect === "tsx" });
   if (!render) {
     return { findings: [], candidates: [], dialect, parsed: false, html: "" };
   }
-
-  const doc = options.document;
-  const metaByElement = install(doc, render);
-  const html = doc.documentElement.innerHTML;
 
   const disabled = new Set<string>([
     ...SOURCE_MODE_DISABLED_RULES,
@@ -60,98 +64,152 @@ export function auditSource(options: AuditSourceOptions): SourceAuditResult {
     componentMode: true,
   };
 
-  clearAllCaches();
-  const violations = [...runAudit(doc, auditOptions).violations];
-
-  // The lone page-level carve-out: a file with a literal intrinsic `<html>` can
-  // honestly be asked whether it set a lang. componentMode dropped the rule, so
-  // it runs on its own.
-  if (render.htmlNodeIndex !== null && !disabled.has(HTML_ELEMENT_RULE)) {
-    const rule = getRuleById(HTML_ELEMENT_RULE);
-    if (rule) violations.push(...rule.run(doc));
-  }
-
+  const doc = options.document;
   const findings: SourceFinding[] = [];
   const candidates: SourceCandidate[] = [];
+  const documents: string[] = [];
 
-  for (const violation of violations) {
-    const element = elementFor(doc, violation);
-    if (!element) continue;
+  // One document per root. See SourceTree for why they cannot share one.
+  for (const tree of render.trees) {
+    const installed = install(doc, tree, render.nodes);
+    const { metaByElement } = installed;
+    documents.push(clean(doc.documentElement.innerHTML));
 
-    const own = metaByElement.get(element);
-    const anchor = own ?? nearestMeta(element, metaByElement);
-    // Nothing this package emitted: not a claim about the source, so not ours
-    // to report. Same posture as the ERB path dropping a violation it cannot
-    // place on a line.
-    if (!anchor) continue;
+    clearAllCaches();
+    const violations = [...runAudit(doc, auditOptions).violations];
 
-    const finding: SourceFinding = {
-      ruleId: violation.ruleId,
-      impact: violation.impact,
-      message: violation.message,
-      context: violation.context,
-      html: violation.html,
-      selector: violation.selector,
-      line: anchor.line,
-      column: anchor.column,
-      file: options.filename,
-    };
+    // The lone page-level carve-out: a file with a literal intrinsic `<html>` can
+    // honestly be asked whether it set a lang. componentMode dropped the rule, so
+    // it runs on its own.
+    if (tree.htmlNodeIndex !== null && !disabled.has(HTML_ELEMENT_RULE)) {
+      const rule = getRuleById(HTML_ELEMENT_RULE);
+      if (rule) violations.push(...rule.run(doc));
+    }
 
-    const unknown = unprovable(violation, element, own ?? anchor, doc, metaByElement, render);
-    if (unknown) candidates.push({ ...finding, unknown });
-    else findings.push(finding);
+    for (const violation of violations) {
+      const element = locate(doc, violation, installed);
+      if (!element) continue;
+
+      const own = metaByElement.get(element);
+      const anchor = own ?? nearestMeta(element, metaByElement);
+      // Nothing this package emitted: not a claim about the source, so not ours
+      // to report. Same posture as the ERB path dropping a violation it cannot
+      // place on a line.
+      if (!anchor) continue;
+
+      const finding: SourceFinding = {
+        ruleId: violation.ruleId,
+        impact: violation.impact,
+        message: clean(violation.message),
+        context: violation.context ? clean(violation.context) : undefined,
+        html: clean(violation.html),
+        selector: violation.selector,
+        line: anchor.line,
+        column: anchor.column,
+        file: options.filename,
+      };
+
+      const unknown = unprovable(violation, element, own ?? anchor, doc, metaByElement, tree);
+      if (unknown) candidates.push({ ...finding, unknown });
+      else findings.push(finding);
+    }
   }
 
   findings.sort(byPosition);
   candidates.sort(byPosition);
+  const html = documents.join("\n");
 
   return { findings, candidates, dialect, parsed: true, html };
+}
+
+/**
+ * Why this file has nothing to answer for, or null when it does. Both reasons
+ * are about the file as a whole, so they are decided before it is even parsed.
+ */
+function outOfScope(options: AuditSourceOptions): SourceAuditResult["skipped"] {
+  if (nonDomRenderer(options.source, options.filename)) return "non-dom-renderer";
+  if (!options.includeTestFiles && testFile(options.filename)) return "test-file";
+  return undefined;
 }
 
 function byPosition(a: SourceFinding, b: SourceFinding): number {
   return a.line - b.line || a.column - b.column || a.ruleId.localeCompare(b.ruleId);
 }
 
+interface Installed {
+  metaByElement: Map<Element, NodeMeta>;
+  elementByIndex: Map<number, Element>;
+}
+
 /**
- * Write the synthetic document, then read the node table out of the marker
- * attributes and remove them. The engine — and every HTML snippet it quotes
- * back into a review comment — sees a document with nothing of ours in it.
+ * Write the synthetic document and read the node table out of the marker
+ * attributes.
+ *
+ * The markers stay on the elements through the audit, and that is deliberate: a
+ * rule that reports by CSS selector can hand back a selector that matches more
+ * than one element — `<a href={blog}>` and `<a href={docs}>` both render
+ * `href="unknown"`, so both get the same selector and the first one wins. Every
+ * finding then lands on the wrong line. The marker is exact, and it comes back in
+ * the violation's own HTML snippet. `clean` strips it from everything a caller
+ * ever reads.
  */
-function install(doc: Document, render: SourceRender): Map<Element, NodeMeta> {
+function install(doc: Document, tree: SourceTree, nodes: NodeMeta[]): Installed {
   const root = doc.documentElement;
   for (const name of root.getAttributeNames()) root.removeAttribute(name);
-  root.innerHTML = `<head>${render.headHtml}</head><body>${render.bodyHtml}</body>`;
+  root.innerHTML = `<head>${tree.headHtml}</head><body>${wrapped(tree)}</body>`;
 
-  for (const [name, value] of render.htmlAttributes) {
+  for (const [name, value] of tree.htmlAttributes) {
     try {
       root.setAttribute(name, value);
     } catch {
       // An expression-named attribute is not a name the DOM accepts; skip it.
     }
   }
-  if (render.htmlNodeIndex !== null) {
-    root.setAttribute(MARKER_ATTRIBUTE, String(render.htmlNodeIndex));
+  if (tree.htmlNodeIndex !== null) {
+    root.setAttribute(MARKER_ATTRIBUTE, String(tree.htmlNodeIndex));
   }
 
   // Walked rather than queried: a plain tree walk asks nothing of the host's
   // selector engine, which not every DOM implementation gets right for attribute
   // selectors.
   const metaByElement = new Map<Element, NodeMeta>();
+  const elementByIndex = new Map<number, Element>();
   const visit = (element: Element): void => {
     const marker = element.getAttribute(MARKER_ATTRIBUTE);
     if (marker !== null) {
-      element.removeAttribute(MARKER_ATTRIBUTE);
-      const meta = render.nodes[Number(marker)];
-      if (meta) metaByElement.set(element, meta);
+      const index = Number(marker);
+      const meta = nodes[index];
+      if (meta) {
+        metaByElement.set(element, meta);
+        elementByIndex.set(index, element);
+      }
     }
     for (const child of element.children) visit(child);
   };
   visit(root);
-  return metaByElement;
+  return { metaByElement, elementByIndex };
 }
 
-/** Rules report an element directly or by selector; either way we need it. */
-function elementFor(doc: Document, violation: Violation): Element | null {
+/** The marker as it appears at the front of an element's own HTML snippet. */
+const MARKED_SNIPPET = new RegExp(`^<[a-z][a-z0-9-]*\\s+${MARKER_ATTRIBUTE}="(\\d+)"`);
+const MARKER_PATTERN = new RegExp(`\\s?${MARKER_ATTRIBUTE}="\\d+"`, "g");
+
+/** Everything a caller reads comes back with nothing of ours in it. */
+function clean(text: string): string {
+  return text.replace(MARKER_PATTERN, "");
+}
+
+/**
+ * The element a violation is about. Its marker comes first: the snippet a rule
+ * quotes is the element's own HTML, so the marker in it is proof of identity,
+ * where a selector is only a guess that happens to be unique most of the time.
+ */
+function locate(doc: Document, violation: Violation, installed: Installed): Element | null {
+  const marked = MARKED_SNIPPET.exec(violation.html);
+  if (marked) {
+    const element = installed.elementByIndex.get(Number(marked[1]));
+    if (element) return element;
+  }
   if (violation.element) return violation.element;
   try {
     return doc.querySelector(violation.selector);
@@ -220,16 +278,25 @@ function attributeUnknown(meta: NodeMeta, ruleId: string): SourceUnknown | null 
   return null;
 }
 
-/** Where the container is, for a rule that reports one of its members. */
-function containerFor(
-  ruleId: string,
-  element: Element,
-  metaByElement: Map<Element, NodeMeta>,
-): NodeMeta | undefined {
-  const location = CONTAINER_MEMBER_RULES[ruleId];
-  if (!location) return metaByElement.get(element);
-  const container = location === "parent" ? element.parentElement : element.closest("table");
-  return container ? metaByElement.get(container) : undefined;
+/** Which element a rule reads the contents of: the subject, or its container. */
+function containerFor(ruleId: string, element: Element): Element | null {
+  const member = CONTAINER_MEMBER_RULES[ruleId];
+  if (!member) return element;
+
+  // The bare-text branch reports the container itself, and the only way to tell
+  // that apart from a member report is the text: a container is the subject when
+  // it holds text of its own.
+  const tag = element.tagName.toLowerCase();
+  if (member.containerTags.includes(tag) && hasDirectText(element)) return element;
+
+  return member.ancestor === "parent" ? element.parentElement : element.closest("table");
+}
+
+function hasDirectText(element: Element): boolean {
+  for (const node of element.childNodes) {
+    if (node.nodeType === 3 && node.textContent && node.textContent.trim()) return true;
+  }
+  return false;
 }
 
 /**
@@ -242,7 +309,7 @@ function unprovable(
   meta: NodeMeta,
   doc: Document,
   metaByElement: Map<Element, NodeMeta>,
-  render: SourceRender,
+  tree: SourceTree,
 ): SourceUnknown | null {
   // An element whose own hiding is unknown may not be in the accessibility tree
   // at all, and neither may anything under it.
@@ -265,13 +332,24 @@ function unprovable(
     // Most of these rules report the container itself; the container-member
     // rules report the offending child, and then it is the container's unknowns
     // that decide.
-    const container = containerFor(violation.ruleId, element, metaByElement) ?? meta;
-    if (container.unknowableChild) {
+    const containerElement = containerFor(violation.ruleId, element);
+    const container = containerElement ? metaByElement.get(containerElement) : undefined;
+    if (!container) {
+      // No container of the author's: either the fragment's parent is in the file
+      // that renders it, or it is the `<table>` we invented to make a lone `<tr>`
+      // parseable. Either way the question belongs to another file.
       return {
-        kind: container.unknowableChild.kind,
-        expression: container.unknowableChild.expression,
-        detail: container.unknowableChild.detail,
+        kind: "external-container",
+        detail: `the ${containerElement ? containerElement.tagName.toLowerCase() : "container"} this rule reads is not in this file`,
       };
+    }
+    // Container integrity reads one level down; everything else — every
+    // accessible name, every table's cells — reads the whole subtree.
+    const unknown = DIRECT_CHILD_RULES.has(violation.ruleId)
+      ? container.unknowableChild
+      : container.unknownContent;
+    if (unknown) {
+      return { kind: unknown.kind, expression: unknown.expression, detail: unknown.detail };
     }
     const containerAttributes = attributeUnknown(container, violation.ruleId);
     if (containerAttributes) return containerAttributes;
@@ -292,17 +370,13 @@ function unprovable(
     }
   }
 
-  // Both arms of a conditional are emitted, and so is every component in the
-  // file, so document order here is not an order any user ever sees.
-  if (
-    DOC_ORDER_DEPENDENT_RULES.has(violation.ruleId) &&
-    (render.hasBranch || render.rootCount > 1)
-  ) {
+  // Both arms of a conditional are emitted, so document order inside this
+  // component is not an order any user ever sees. (Order *between* components
+  // never arises: each root is audited on its own.)
+  if (DOC_ORDER_DEPENDENT_RULES.has(violation.ruleId) && tree.hasBranch) {
     return {
       kind: "exclusive-branches",
-      detail: render.hasBranch
-        ? "this file emits exclusive branches, so document order is not a real order"
-        : "this file defines several independent trees, so document order is not a real order",
+      detail: "this component emits exclusive branches, so document order is not a real order",
     };
   }
 

--- a/source/src/audit.ts
+++ b/source/src/audit.ts
@@ -1,0 +1,310 @@
+import { clearAllCaches, getRuleById, runAudit, type AuditOptions } from "@accesslint/core";
+import type { Violation } from "@accesslint/core";
+import { MARKER_ATTRIBUTE, type NodeMeta } from "./emit";
+import { renderJsx } from "./jsx";
+import type { SourceRender } from "./render";
+import {
+  attributeDependencies,
+  CHILD_DEPENDENT_RULES,
+  CONTAINER_MEMBER_RULES,
+  DEPENDS_ON_ANY_UNKNOWN,
+  DOC_ORDER_DEPENDENT_RULES,
+  FRAGMENT_DISABLED_RULES,
+  HTML_ELEMENT_RULE,
+  NAME_FAMILY_RULES,
+  SOURCE_MODE_DISABLED_RULES,
+} from "./semantics";
+import type {
+  AuditSourceOptions,
+  Dialect,
+  SourceAuditResult,
+  SourceCandidate,
+  SourceFinding,
+  SourceUnknown,
+} from "./types";
+
+/** The dialect a filename names, or null when it names none of ours. */
+export function detectDialect(filename?: string): Dialect | null {
+  if (!filename) return null;
+  if (/\.tsx$/i.test(filename)) return "tsx";
+  if (/\.jsx$/i.test(filename)) return "jsx";
+  return null;
+}
+
+/**
+ * Audit a component file. Findings are violations the source proves; candidates
+ * are violations the engine reported that the source cannot prove, each carrying
+ * the unknown that stopped it. Only findings are safe to post as review
+ * comments.
+ */
+export function auditSource(options: AuditSourceOptions): SourceAuditResult {
+  // No filename and no dialect: parse as TSX, the superset that also reads JSX.
+  const dialect = options.dialect ?? detectDialect(options.filename) ?? "tsx";
+  const render = renderJsx(options.source, { typescript: dialect === "tsx" });
+  if (!render) {
+    return { findings: [], candidates: [], dialect, parsed: false, html: "" };
+  }
+
+  const doc = options.document;
+  const metaByElement = install(doc, render);
+  const html = doc.documentElement.innerHTML;
+
+  const disabled = new Set<string>([
+    ...SOURCE_MODE_DISABLED_RULES,
+    ...FRAGMENT_DISABLED_RULES,
+    ...(options.auditOptions?.disabledRules ?? []),
+  ]);
+  const auditOptions: AuditOptions = {
+    ...options.auditOptions,
+    disabledRules: [...disabled],
+    componentMode: true,
+  };
+
+  clearAllCaches();
+  const violations = [...runAudit(doc, auditOptions).violations];
+
+  // The lone page-level carve-out: a file with a literal intrinsic `<html>` can
+  // honestly be asked whether it set a lang. componentMode dropped the rule, so
+  // it runs on its own.
+  if (render.htmlNodeIndex !== null && !disabled.has(HTML_ELEMENT_RULE)) {
+    const rule = getRuleById(HTML_ELEMENT_RULE);
+    if (rule) violations.push(...rule.run(doc));
+  }
+
+  const findings: SourceFinding[] = [];
+  const candidates: SourceCandidate[] = [];
+
+  for (const violation of violations) {
+    const element = elementFor(doc, violation);
+    if (!element) continue;
+
+    const own = metaByElement.get(element);
+    const anchor = own ?? nearestMeta(element, metaByElement);
+    // Nothing this package emitted: not a claim about the source, so not ours
+    // to report. Same posture as the ERB path dropping a violation it cannot
+    // place on a line.
+    if (!anchor) continue;
+
+    const finding: SourceFinding = {
+      ruleId: violation.ruleId,
+      impact: violation.impact,
+      message: violation.message,
+      context: violation.context,
+      html: violation.html,
+      selector: violation.selector,
+      line: anchor.line,
+      column: anchor.column,
+      file: options.filename,
+    };
+
+    const unknown = unprovable(violation, element, own ?? anchor, doc, metaByElement, render);
+    if (unknown) candidates.push({ ...finding, unknown });
+    else findings.push(finding);
+  }
+
+  findings.sort(byPosition);
+  candidates.sort(byPosition);
+
+  return { findings, candidates, dialect, parsed: true, html };
+}
+
+function byPosition(a: SourceFinding, b: SourceFinding): number {
+  return a.line - b.line || a.column - b.column || a.ruleId.localeCompare(b.ruleId);
+}
+
+/**
+ * Write the synthetic document, then read the node table out of the marker
+ * attributes and remove them. The engine — and every HTML snippet it quotes
+ * back into a review comment — sees a document with nothing of ours in it.
+ */
+function install(doc: Document, render: SourceRender): Map<Element, NodeMeta> {
+  const root = doc.documentElement;
+  for (const name of root.getAttributeNames()) root.removeAttribute(name);
+  root.innerHTML = `<head>${render.headHtml}</head><body>${render.bodyHtml}</body>`;
+
+  for (const [name, value] of render.htmlAttributes) {
+    try {
+      root.setAttribute(name, value);
+    } catch {
+      // An expression-named attribute is not a name the DOM accepts; skip it.
+    }
+  }
+  if (render.htmlNodeIndex !== null) {
+    root.setAttribute(MARKER_ATTRIBUTE, String(render.htmlNodeIndex));
+  }
+
+  // Walked rather than queried: a plain tree walk asks nothing of the host's
+  // selector engine, which not every DOM implementation gets right for attribute
+  // selectors.
+  const metaByElement = new Map<Element, NodeMeta>();
+  const visit = (element: Element): void => {
+    const marker = element.getAttribute(MARKER_ATTRIBUTE);
+    if (marker !== null) {
+      element.removeAttribute(MARKER_ATTRIBUTE);
+      const meta = render.nodes[Number(marker)];
+      if (meta) metaByElement.set(element, meta);
+    }
+    for (const child of element.children) visit(child);
+  };
+  visit(root);
+  return metaByElement;
+}
+
+/** Rules report an element directly or by selector; either way we need it. */
+function elementFor(doc: Document, violation: Violation): Element | null {
+  if (violation.element) return violation.element;
+  try {
+    return doc.querySelector(violation.selector);
+  } catch {
+    return null;
+  }
+}
+
+function nearestMeta(
+  element: Element,
+  metaByElement: Map<Element, NodeMeta>,
+): NodeMeta | undefined {
+  let current: Element | null = element.parentElement;
+  while (current) {
+    const meta = metaByElement.get(current);
+    if (meta) return meta;
+    current = current.parentElement;
+  }
+  return undefined;
+}
+
+/**
+ * The attribute-shaped unknowns for one rule on one element: an expression value
+ * for an attribute the rule reads, and the spread calculus — a spread means the
+ * rule's attributes are only known where the source writes them *after* the
+ * spread, since a spread can supply what the element does not name.
+ */
+function attributeUnknown(meta: NodeMeta, ruleId: string): SourceUnknown | null {
+  const dependencies = attributeDependencies(ruleId);
+
+  for (const [attribute, unknown] of meta.unknownAttributes) {
+    if (dependencies !== DEPENDS_ON_ANY_UNKNOWN && !dependencies.includes(attribute)) continue;
+    if (unknown.cause === "spread") {
+      return {
+        kind: "spread",
+        attribute,
+        expression: unknown.expression,
+        detail: `${attribute} is written before {...${unknown.expression}}, which can override it`,
+      };
+    }
+    return {
+      kind: "unknown-attribute-value",
+      attribute,
+      expression: unknown.expression,
+      detail: `${attribute} is set from \`${unknown.expression}\`, so its value is unknown here`,
+    };
+  }
+
+  if (!meta.spread) return null;
+  if (dependencies === DEPENDS_ON_ANY_UNKNOWN) {
+    return {
+      kind: "spread",
+      expression: meta.spread.expression,
+      detail: `<${meta.tag}> spreads {...${meta.spread.expression}}, which may carry attributes this file does not name`,
+    };
+  }
+  for (const attribute of dependencies) {
+    if (meta.pinnedAfterSpread.has(attribute)) continue;
+    return {
+      kind: "spread",
+      attribute,
+      expression: meta.spread.expression,
+      detail: `{...${meta.spread.expression}} may supply ${attribute}, which this file does not set after it`,
+    };
+  }
+  return null;
+}
+
+/** Where the container is, for a rule that reports one of its members. */
+function containerFor(
+  ruleId: string,
+  element: Element,
+  metaByElement: Map<Element, NodeMeta>,
+): NodeMeta | undefined {
+  const location = CONTAINER_MEMBER_RULES[ruleId];
+  if (!location) return metaByElement.get(element);
+  const container = location === "parent" ? element.parentElement : element.closest("table");
+  return container ? metaByElement.get(container) : undefined;
+}
+
+/**
+ * The unknown that stops this violation from being a finding, or null when the
+ * source pins down everything the rule read.
+ */
+function unprovable(
+  violation: Violation,
+  element: Element,
+  meta: NodeMeta,
+  doc: Document,
+  metaByElement: Map<Element, NodeMeta>,
+  render: SourceRender,
+): SourceUnknown | null {
+  // An element whose own hiding is unknown may not be in the accessibility tree
+  // at all, and neither may anything under it.
+  for (let node: Element | null = element; node; node = node.parentElement) {
+    const hidden = metaByElement.get(node)?.subtreeUnknown;
+    if (hidden) {
+      return {
+        kind: "unknown-semantics",
+        attribute: hidden.attribute,
+        expression: hidden.expression,
+        detail: `${hidden.attribute}={${hidden.expression}} may remove this from the accessibility tree`,
+      };
+    }
+  }
+
+  const attributes = attributeUnknown(meta, violation.ruleId);
+  if (attributes) return attributes;
+
+  if (CHILD_DEPENDENT_RULES.has(violation.ruleId)) {
+    // Most of these rules report the container itself; the container-member
+    // rules report the offending child, and then it is the container's unknowns
+    // that decide.
+    const container = containerFor(violation.ruleId, element, metaByElement) ?? meta;
+    if (container.unknowableChild) {
+      return {
+        kind: container.unknowableChild.kind,
+        expression: container.unknowableChild.expression,
+        detail: container.unknowableChild.detail,
+      };
+    }
+    const containerAttributes = attributeUnknown(container, violation.ruleId);
+    if (containerAttributes) return containerAttributes;
+  }
+
+  // A component is normally named by the page that renders it, so an
+  // aria-labelledby target this file does not define is not a missing name.
+  if (NAME_FAMILY_RULES.has(violation.ruleId)) {
+    const labelledby = element.getAttribute("aria-labelledby");
+    const missing = (labelledby ?? "").split(/\s+/).filter((id) => id && !doc.getElementById(id));
+    if (missing.length > 0) {
+      return {
+        kind: "external-idref",
+        attribute: "aria-labelledby",
+        expression: missing.join(" "),
+        detail: `aria-labelledby points at ${missing.join(", ")}, which this file does not define`,
+      };
+    }
+  }
+
+  // Both arms of a conditional are emitted, and so is every component in the
+  // file, so document order here is not an order any user ever sees.
+  if (
+    DOC_ORDER_DEPENDENT_RULES.has(violation.ruleId) &&
+    (render.hasBranch || render.rootCount > 1)
+  ) {
+    return {
+      kind: "exclusive-branches",
+      detail: render.hasBranch
+        ? "this file emits exclusive branches, so document order is not a real order"
+        : "this file defines several independent trees, so document order is not a real order",
+    };
+  }
+
+  return null;
+}

--- a/source/src/emit.ts
+++ b/source/src/emit.ts
@@ -1,0 +1,78 @@
+import { VOID_ELEMENTS } from "./semantics";
+
+/**
+ * Every element the adapter emits carries this attribute, holding its index
+ * into the node table. The audit layer reads the table into an
+ * element-to-metadata map and then *removes* the attribute, so the engine — and
+ * every HTML snippet it quotes back — sees a document with nothing of ours in
+ * it.
+ */
+export const MARKER_ATTRIBUTE = "data-accesslint-node";
+
+/** What the source said, and did not say, about one emitted element. */
+export interface NodeMeta {
+  /** 1-based source line of the element's opening tag. */
+  line: number;
+  /** 1-based source column of the element's opening tag. */
+  column: number;
+  tag: string;
+  /** Set when the element carries `{...spread}`: absence is unprovable. */
+  spread?: { expression: string };
+  /** Attributes whose value the source does not pin down, and why. */
+  unknownAttributes: Map<string, { expression: string; cause: "expression" | "spread" }>;
+  /**
+   * Attributes written after the last spread. Their state — a value, or
+   * provably absent — is the one thing a spread cannot take back.
+   */
+  pinnedAfterSpread: Set<string>;
+  /** An unknown that hides the element and everything under it. */
+  subtreeUnknown?: { attribute: string; expression: string };
+  /** Set when a child's contents are unknown: a component, or an opaque expression. */
+  unknowableChild?: {
+    kind: "component-child" | "opaque-expression";
+    detail: string;
+    expression?: string;
+  };
+  /** True when the element is emitted from one arm of an exclusive branch. */
+  branch: boolean;
+}
+
+// JSX text and attribute strings carry HTML entities through to the DOM
+// unchanged, so an `&` that already starts one is left alone rather than
+// escaped into visible `&amp;nbsp;` text.
+const BARE_AMPERSAND = /&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);)/g;
+
+export function escapeText(text: string): string {
+  return text.replace(BARE_AMPERSAND, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function escapeAttribute(value: string): string {
+  return value
+    .replace(BARE_AMPERSAND, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Collects the node table while the adapter walks the AST, and serializes
+ * elements into the synthetic HTML the engine parses.
+ */
+export class Emitter {
+  readonly nodes: NodeMeta[] = [];
+
+  allocate(meta: NodeMeta): number {
+    this.nodes.push(meta);
+    return this.nodes.length - 1;
+  }
+
+  element(index: number, tag: string, attributes: [string, string][], children: string): string {
+    const parts = [`${MARKER_ATTRIBUTE}="${index}"`];
+    for (const [name, value] of attributes) {
+      parts.push(`${name}="${escapeAttribute(value)}"`);
+    }
+    const open = `<${tag} ${parts.join(" ")}`;
+    if (VOID_ELEMENTS.has(tag)) return `${open} />`;
+    return `${open}>${children}</${tag}>`;
+  }
+}

--- a/source/src/emit.ts
+++ b/source/src/emit.ts
@@ -27,14 +27,26 @@ export interface NodeMeta {
   pinnedAfterSpread: Set<string>;
   /** An unknown that hides the element and everything under it. */
   subtreeUnknown?: { attribute: string; expression: string };
-  /** Set when a child's contents are unknown: a component, or an opaque expression. */
-  unknowableChild?: {
-    kind: "component-child" | "opaque-expression";
-    detail: string;
-    expression?: string;
-  };
+  /**
+   * Set when a *direct* child's contents are unknown: a component, or an opaque
+   * expression. This is what the container-integrity rules read, and they only
+   * look one level down.
+   */
+  unknowableChild?: Unknowable;
+  /**
+   * Set when anything anywhere below the element is unknown. An accessible name
+   * is computed from the whole subtree, so `<button><div>{label}</div></button>`
+   * is a named button even though the button's own children are both known.
+   */
+  unknownContent?: Unknowable;
   /** True when the element is emitted from one arm of an exclusive branch. */
   branch: boolean;
+}
+
+export interface Unknowable {
+  kind: "component-child" | "opaque-expression";
+  detail: string;
+  expression?: string;
 }
 
 // JSX text and attribute strings carry HTML entities through to the DOM

--- a/source/src/index.ts
+++ b/source/src/index.ts
@@ -1,0 +1,24 @@
+export { auditSource, detectDialect } from "./audit";
+export {
+  CHILD_DEPENDENT_RULES,
+  DOC_ORDER_DEPENDENT_RULES,
+  FRAGMENT_DISABLED_RULES,
+  HTML_ELEMENT_RULE,
+  NAME_FAMILY_RULES,
+  RULE_ATTRIBUTE_DEPENDENCIES,
+  SOURCE_MODE_DISABLED_RULES,
+  TEXT_PLACEHOLDER,
+} from "./semantics";
+export { renderJsx } from "./jsx";
+export type { RenderJsxOptions } from "./jsx";
+export type { SourceRender } from "./render";
+export type { NodeMeta } from "./emit";
+export type {
+  AuditSourceOptions,
+  Dialect,
+  SourceAuditResult,
+  SourceCandidate,
+  SourceFinding,
+  SourceUnknown,
+  UnknownKind,
+} from "./types";

--- a/source/src/index.ts
+++ b/source/src/index.ts
@@ -1,14 +1,5 @@
 export { auditSource, detectDialect } from "./audit";
-export {
-  CHILD_DEPENDENT_RULES,
-  DOC_ORDER_DEPENDENT_RULES,
-  FRAGMENT_DISABLED_RULES,
-  HTML_ELEMENT_RULE,
-  NAME_FAMILY_RULES,
-  RULE_ATTRIBUTE_DEPENDENCIES,
-  SOURCE_MODE_DISABLED_RULES,
-  TEXT_PLACEHOLDER,
-} from "./semantics";
+export { HTML_ELEMENT_RULE, SOURCE_MODE_DISABLED_RULES, TEXT_PLACEHOLDER } from "./semantics";
 export { renderJsx } from "./jsx";
 export type { RenderJsxOptions } from "./jsx";
 export type { SourceRender } from "./render";

--- a/source/src/invariants.test.ts
+++ b/source/src/invariants.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { auditSource } from "./audit";
+import { attributeName } from "./jsx/attributes";
+import { attributeDependencies, CHILD_DEPENDENT_RULES, DEPENDS_ON_ANY_UNKNOWN } from "./semantics";
+import { testDocument } from "./test-dom";
+import type { SourceAuditResult } from "./types";
+
+// The decision-11 invariants, stated as properties over a corpus of component
+// shapes crossed with the mutations that introduce each kind of unknown. Every
+// one of these is a claim about the package as a whole, not about a rule: adding
+// an unknown to a file can only ever remove findings, and a removed finding is
+// always still recorded as a candidate.
+
+/** One element per rule family that fires on a static, fully-known shape. */
+const SHAPES = [
+  `<img src="/a.png" />`,
+  `<img src="/a.png" alt=" " />`,
+  `<button></button>`,
+  `<a href="/x"></a>`,
+  `<h2></h2>`,
+  `<ul><div>Item</div></ul>`,
+  `<div tabIndex={5}></div>`,
+  `<input type="text" autoComplete="banana" />`,
+  `<div role="banana"></div>`,
+  `<div aria-lbel="Close"></div>`,
+  `<table><tr><td>1</td></tr></table>`,
+  `<dl><span>Term</span></dl>`,
+  `<video src="/a.mp4" controls></video>`,
+];
+
+function component(jsx: string): string {
+  return `export const Shape = (props) => (\n  ${jsx}\n);`;
+}
+
+function audit(jsx: string): SourceAuditResult {
+  return auditSource({
+    source: component(jsx),
+    filename: "Shape.tsx",
+    document: testDocument(),
+  });
+}
+
+function ids(findings: { ruleId: string }[]): Set<string> {
+  return new Set(findings.map((finding) => finding.ruleId));
+}
+
+/** `<img …/>` becomes `<img {...props} …/>`: the spread comes first. */
+function spreadFirst(jsx: string): string {
+  return jsx.replace(/^<([a-zA-Z][\w-]*)/, "<$1 {...props}");
+}
+
+/** Every literal attribute value becomes an expression. */
+function expressionValues(jsx: string): string {
+  return jsx.replace(/="([^"]*)"/g, "={value}");
+}
+
+/** An opaque expression joins the outermost element's children. */
+function opaqueChild(jsx: string): string {
+  const match = /^<([a-zA-Z][\w-]*)([^>]*)>/.exec(jsx);
+  if (!match || match[2].trimEnd().endsWith("/")) return jsx;
+  return jsx.replace(match[0], `${match[0]}{stuff}`);
+}
+
+/** The HTML attribute names a shape writes, however their values are given. */
+function attributeNames(jsx: string): string[] {
+  return names(jsx, /([a-zA-Z][\w:-]*)=["{]/g);
+}
+
+/** Only the string-literal ones — the values `expressionValues` makes unknown. */
+function quotedAttributeNames(jsx: string): string[] {
+  return names(jsx, /([a-zA-Z][\w:-]*)="/g);
+}
+
+function names(jsx: string, pattern: RegExp): string[] {
+  return [...jsx.matchAll(pattern)]
+    .map(([, prop]) => attributeName(prop))
+    .filter((name): name is string => name !== null);
+}
+
+describe("silence only grows", () => {
+  for (const shape of SHAPES) {
+    it(`no mutation of ${shape} invents a finding`, () => {
+      const base = ids(audit(shape).findings);
+      for (const mutate of [spreadFirst, expressionValues, opaqueChild]) {
+        const mutated = audit(mutate(shape));
+        for (const ruleId of ids(mutated.findings)) {
+          expect(base, `${mutate.name} on ${shape} invented ${ruleId}`).toContain(ruleId);
+        }
+      }
+    });
+
+    // Stated for the spread only, and deliberately. A spread leaves the
+    // evidence alone — the engine still fires, and suppression records a
+    // candidate for the unsuppression layer to adjudicate. The other two
+    // mutations *replace* the evidence with a stand-in, so the engine may never
+    // fire at all: `alt={label}` reads as a named image, and there is no
+    // violation left to record. That is the accepted edge of the candidate
+    // model, not a leak.
+    it(`every finding ${shape} proves becomes a candidate under a spread`, () => {
+      const base = ids(audit(shape).findings);
+      const mutated = audit(spreadFirst(shape));
+      const kept = new Set([...ids(mutated.findings), ...ids(mutated.candidates)]);
+      for (const ruleId of base) {
+        expect(kept, `a spread on ${shape} dropped ${ruleId} silently`).toContain(ruleId);
+      }
+    });
+  }
+});
+
+describe("a spread makes absence unprovable", () => {
+  for (const shape of SHAPES) {
+    it(`${shape} keeps only rules the source pins after the spread`, () => {
+      // The spread comes first, so every attribute the source writes is pinned
+      // and nothing else is. A rule survives only if the source writes every
+      // attribute it reads — and a rule with no dependency table never does.
+      const pinned = new Set(attributeNames(shape));
+      for (const ruleId of ids(audit(spreadFirst(shape)).findings)) {
+        const dependencies = attributeDependencies(ruleId);
+        expect(dependencies, `${ruleId} has no dependency table`).not.toBe(DEPENDS_ON_ANY_UNKNOWN);
+        for (const attribute of dependencies) {
+          expect(pinned, `${ruleId} survived on an unpinned ${attribute}`).toContain(attribute);
+        }
+      }
+    });
+  }
+});
+
+describe("an expression value silences the rules that read it", () => {
+  for (const shape of SHAPES) {
+    const attributes = quotedAttributeNames(shape);
+    if (attributes.length === 0) continue;
+    it(`${shape} silences every rule reading ${attributes.join(", ")}`, () => {
+      const mutated = audit(expressionValues(shape));
+      for (const ruleId of ids(mutated.findings)) {
+        const dependencies = attributeDependencies(ruleId);
+        expect(dependencies, `${ruleId} read an expression value`).not.toBe(DEPENDS_ON_ANY_UNKNOWN);
+        for (const attribute of attributes) {
+          expect(dependencies, `${ruleId} read ${attribute}`).not.toContain(attribute);
+        }
+      }
+    });
+  }
+});
+
+describe("an opaque child silences the rules that read contents", () => {
+  for (const shape of SHAPES) {
+    const mutated = opaqueChild(shape);
+    if (mutated === shape) continue;
+    it(`${shape} silences its container rules`, () => {
+      for (const ruleId of ids(audit(mutated).findings)) {
+        expect(CHILD_DEPENDENT_RULES, `${ruleId} read unknown contents`).not.toContain(ruleId);
+      }
+    });
+  }
+});
+
+describe("nothing of ours reaches the output", () => {
+  it("never leaks a marker attribute", () => {
+    for (const shape of SHAPES) {
+      for (const mutate of [(s: string) => s, spreadFirst, expressionValues, opaqueChild]) {
+        const result = audit(mutate(shape));
+        expect(result.html).not.toContain("data-accesslint");
+        for (const finding of [...result.findings, ...result.candidates]) {
+          expect(finding.html).not.toContain("data-accesslint");
+          expect(finding.context ?? "").not.toContain("data-accesslint");
+        }
+      }
+    }
+  });
+});
+
+describe("an unreadable file is silent, not fatal", () => {
+  const broken = [
+    "",
+    "   ",
+    "export const A = () => <div>",
+    "<<<>>>",
+    "%%%not javascript at all%%%",
+    "export const A = () => <div className={{{ }} />",
+    "\u0000\u0001\u0002",
+    `export const A = () => <div>${"<span>".repeat(200)}`,
+  ];
+
+  for (const source of broken) {
+    it(`survives ${JSON.stringify(source.slice(0, 24))}`, () => {
+      const result = auditSource({ source, filename: "Broken.tsx", document: testDocument() });
+      if (!result.parsed) {
+        expect(result.findings).toEqual([]);
+        expect(result.candidates).toEqual([]);
+      }
+    });
+  }
+});

--- a/source/src/jsx/attributes.ts
+++ b/source/src/jsx/attributes.ts
@@ -54,7 +54,7 @@ function kebab(property: string): string {
 /**
  * A style object is worth resolving rather than dropping: an element with
  * `display: none` is out of the accessibility tree, and rules skip it. Drop it
- * blind and every hidden element becomes a finding.
+ * unread and every hidden element becomes a finding.
  *
  * Literal declarations are emitted. A non-literal value is skipped when its
  * property cannot hide anything, and makes the whole style unknown when it can

--- a/source/src/jsx/attributes.ts
+++ b/source/src/jsx/attributes.ts
@@ -1,0 +1,85 @@
+import { VISIBILITY_STYLE_PROPERTIES } from "../semantics";
+
+/**
+ * React prop names that are not the HTML attribute name. Everything else that
+ * arrives camelCased (`tabIndex`, `readOnly`, `maxLength`) lowercases to its
+ * attribute, which is what the HTML parser does anyway; anything already
+ * hyphenated (`aria-*`, `data-*`) is passed through untouched.
+ */
+const RENAMED_PROPS: Record<string, string> = {
+  className: "class",
+  htmlFor: "for",
+  httpEquiv: "http-equiv",
+  acceptCharset: "accept-charset",
+  // React renders these as the plain attribute; the audit cares about the
+  // rendered DOM, not which prop controlled it.
+  defaultValue: "value",
+  defaultChecked: "checked",
+};
+
+/**
+ * Props that exist for React and never reach the DOM. Dropping them is a false
+ * negative at worst: no rule in the corpus reads an event handler, and an
+ * emitted `onclick=""` would be a claim the source does not make.
+ */
+const DROPPED_PROPS = new Set([
+  "key",
+  "ref",
+  "suppressHydrationWarning",
+  "suppressContentEditableWarning",
+]);
+
+/** `children={...}` and `dangerouslySetInnerHTML` are contents, not attributes. */
+export const CONTENT_PROPS = new Set(["children", "dangerouslySetInnerHTML"]);
+
+export function isEventHandlerProp(name: string): boolean {
+  return /^on[A-Z]/.test(name);
+}
+
+/** The HTML attribute name for a JSX prop, or null when it never reaches the DOM. */
+export function attributeName(prop: string): string | null {
+  if (DROPPED_PROPS.has(prop)) return null;
+  if (isEventHandlerProp(prop)) return null;
+  const renamed = RENAMED_PROPS[prop];
+  if (renamed) return renamed;
+  if (prop.includes("-") || prop.includes(":")) return prop;
+  return prop.toLowerCase();
+}
+
+function kebab(property: string): string {
+  if (property.startsWith("--")) return property;
+  return property.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+/**
+ * A style object is worth resolving rather than dropping: an element with
+ * `display: none` is out of the accessibility tree, and rules skip it. Drop it
+ * blind and every hidden element becomes a finding.
+ *
+ * Literal declarations are emitted. A non-literal value is skipped when its
+ * property cannot hide anything, and makes the whole style unknown when it can
+ * — `style={{ display: mode }}` could be `none`.
+ */
+export type StyleResult =
+  | { kind: "known"; css: string }
+  | { kind: "unknown"; reason: "visibility-property" | "opaque" };
+
+export function resolveStyleObject(
+  properties: { property: string | null; literal: string | null }[],
+  hasSpread: boolean,
+): StyleResult {
+  if (hasSpread) return { kind: "unknown", reason: "opaque" };
+  const declarations: string[] = [];
+  for (const { property, literal } of properties) {
+    if (property === null) return { kind: "unknown", reason: "opaque" };
+    const name = kebab(property);
+    if (literal === null) {
+      if (VISIBILITY_STYLE_PROPERTIES.has(name)) {
+        return { kind: "unknown", reason: "visibility-property" };
+      }
+      continue;
+    }
+    declarations.push(`${name}: ${literal}`);
+  }
+  return { kind: "known", css: declarations.join("; ") };
+}

--- a/source/src/jsx/index.ts
+++ b/source/src/jsx/index.ts
@@ -707,29 +707,38 @@ function memberName(name: t.JSXMemberExpression): string {
   return `${object}.${name.property.name}`;
 }
 
+/**
+ * Depth-first walk over anything Babel hands back, skipping bookkeeping keys.
+ * `enter` sees every typed node; returning "stop" keeps the walk out of that
+ * node's children.
+ */
+function walkAst(node: unknown, enter: (node: t.Node) => "stop" | undefined): void {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const item of node) walkAst(item, enter);
+    return;
+  }
+  if (!(node as { type?: string }).type) return;
+  if (enter(node as t.Node) === "stop") return;
+  for (const [key, value] of Object.entries(node)) {
+    if (SKIPPED_AST_KEYS.has(key)) continue;
+    walkAst(value, enter);
+  }
+}
+
 /** Return statements in a function body, not descending into nested functions. */
 function returnedExpressions(body: t.BlockStatement): t.Expression[] {
   const found: t.Expression[] = [];
-  const visit = (node: unknown): void => {
-    if (!node || typeof node !== "object") return;
-    if (Array.isArray(node)) {
-      node.forEach(visit);
-      return;
+  walkAst(body.body, (node) => {
+    if (node.type.endsWith("FunctionExpression") || node.type === "FunctionDeclaration") {
+      return "stop";
     }
-    const type = (node as { type?: string }).type;
-    if (!type) return;
-    if (type.endsWith("FunctionExpression") || type === "FunctionDeclaration") return;
-    if (type === "ReturnStatement") {
-      const argument = (node as t.ReturnStatement).argument;
-      if (argument) found.push(argument);
-      return;
+    if (node.type === "ReturnStatement") {
+      if (node.argument) found.push(node.argument);
+      return "stop";
     }
-    for (const [key, value] of Object.entries(node)) {
-      if (SKIPPED_AST_KEYS.has(key)) continue;
-      visit(value);
-    }
-  };
-  visit(body.body);
+    return undefined;
+  });
   return found;
 }
 
@@ -754,23 +763,12 @@ const SKIPPED_AST_KEYS = new Set([
  */
 function findJsxRoots(ast: t.File): (t.JSXElement | t.JSXFragment)[] {
   const roots: (t.JSXElement | t.JSXFragment)[] = [];
-  const visit = (node: unknown): void => {
-    if (!node || typeof node !== "object") return;
-    if (Array.isArray(node)) {
-      node.forEach(visit);
-      return;
+  walkAst(ast.program.body, (node) => {
+    if (node.type === "JSXElement" || node.type === "JSXFragment") {
+      roots.push(node);
+      return "stop";
     }
-    const type = (node as { type?: string }).type;
-    if (!type) return;
-    if (type === "JSXElement" || type === "JSXFragment") {
-      roots.push(node as t.JSXElement | t.JSXFragment);
-      return;
-    }
-    for (const [key, value] of Object.entries(node)) {
-      if (SKIPPED_AST_KEYS.has(key)) continue;
-      visit(value);
-    }
-  };
-  visit(ast.program.body);
+    return undefined;
+  });
   return roots;
 }

--- a/source/src/jsx/index.ts
+++ b/source/src/jsx/index.ts
@@ -1,7 +1,7 @@
 import { parse, type ParserOptions } from "@babel/parser";
 import type * as t from "@babel/types";
-import { Emitter, escapeText, type NodeMeta } from "../emit";
-import type { SourceRender } from "../render";
+import { Emitter, escapeText, type NodeMeta, type Unknowable } from "../emit";
+import { wrapperFor, type SourceRender, type SourceTree } from "../render";
 import {
   ATTRIBUTE_PLACEHOLDER,
   SUBTREE_SEMANTICS_ATTRIBUTES,
@@ -52,7 +52,10 @@ function parseJsx(source: string, typescript: boolean): t.File | null {
 /** What a child contributes to its parent element beyond markup. */
 interface Emitted {
   html: string;
-  unknowable?: NodeMeta["unknowableChild"];
+  /** Makes the parent's *direct* children unknown. */
+  unknowable?: Unknowable;
+  /** Makes everything in the parent's subtree unknown, however deep it sits. */
+  contentUnknown?: Unknowable;
 }
 
 /** What a child needs to know about where it sits. */
@@ -81,60 +84,81 @@ class JsxAdapter {
   constructor(private readonly source: string) {}
 
   render(ast: t.File): SourceRender {
-    const headParts: string[] = [];
-    const bodyParts: string[] = [];
-    let htmlAttributes: [string, string][] = [];
-    let htmlNodeIndex: number | null = null;
+    const trees: SourceTree[] = [];
+    let htmlRootSeen = false;
 
-    const roots = findJsxRoots(ast);
-    for (const root of roots) {
+    for (const root of findJsxRoots(ast)) {
+      // Each root is its own tree, and its own document later: they are
+      // independent components, and concatenating them lets the HTML parser
+      // rearrange one root's elements around another's.
+      const branchBefore = this.hasBranch;
+      this.hasBranch = false;
+
       if (root.type === "JSXFragment") {
-        bodyParts.push(this.children(root.children, null, false).html);
-        continue;
-      }
-
-      const name = elementName(root.openingElement.name);
-      if (name.intrinsic && name.tag === "html" && htmlNodeIndex === null) {
-        // A root layout's `<html>` is the one page-level shape a component file
-        // can legitimately carry. The document already has an html element, so
-        // this one contributes its attributes to the documentElement and its
-        // head/body children are distributed into the real head and body.
-        const { attributes, meta } = this.attributes(root.openingElement, false, "html");
-        for (const child of root.children) {
-          if (child.type === "JSXElement") {
-            const childName = elementName(child.openingElement.name);
-            if (childName.intrinsic && childName.tag === "head") {
-              headParts.push(
-                this.children(child.children, { tag: "head", textPosition: false }, false).html,
-              );
-              continue;
-            }
-            if (childName.intrinsic && childName.tag === "body") {
-              bodyParts.push(
-                this.children(child.children, { tag: "body", textPosition: false }, false).html,
-              );
-              continue;
-            }
-          }
-          bodyParts.push(this.child(child, { tag: "html", textPosition: false }, false).html);
+        trees.push(this.tree(this.children(root.children, null, false).html));
+      } else {
+        const name = elementName(root.openingElement.name);
+        if (name.intrinsic && name.tag === "html" && !htmlRootSeen) {
+          htmlRootSeen = true;
+          trees.push(this.documentTree(root));
+        } else {
+          trees.push(this.tree(this.node(root, null, false).html));
         }
-        htmlAttributes = attributes;
-        htmlNodeIndex = this.emitter.allocate(meta);
-        continue;
       }
 
-      bodyParts.push(this.node(root, null, false).html);
+      this.hasBranch = branchBefore;
     }
 
+    return { trees, nodes: this.emitter.nodes };
+  }
+
+  private tree(bodyHtml: string, extras: Partial<SourceTree> = {}): SourceTree {
     return {
-      headHtml: headParts.join(""),
-      bodyHtml: bodyParts.join(""),
-      htmlAttributes,
-      htmlNodeIndex,
-      nodes: this.emitter.nodes,
+      headHtml: "",
+      bodyHtml,
+      htmlAttributes: [],
+      htmlNodeIndex: null,
+      wrapper: wrapperFor(bodyHtml),
       hasBranch: this.hasBranch,
-      rootCount: roots.length,
+      ...extras,
     };
+  }
+
+  /**
+   * A root layout's `<html>` is the one page-level shape a component file can
+   * legitimately carry. The document already has an html element, so this one
+   * contributes its attributes to the documentElement and its head/body children
+   * are distributed into the real head and body.
+   */
+  private documentTree(root: t.JSXElement): SourceTree {
+    const headParts: string[] = [];
+    const bodyParts: string[] = [];
+    const { attributes, meta } = this.attributes(root.openingElement, false, "html");
+
+    for (const child of root.children) {
+      if (child.type === "JSXElement") {
+        const childName = elementName(child.openingElement.name);
+        if (childName.intrinsic && childName.tag === "head") {
+          headParts.push(
+            this.children(child.children, { tag: "head", textPosition: false }, false).html,
+          );
+          continue;
+        }
+        if (childName.intrinsic && childName.tag === "body") {
+          bodyParts.push(
+            this.children(child.children, { tag: "body", textPosition: false }, false).html,
+          );
+          continue;
+        }
+      }
+      bodyParts.push(this.child(child, { tag: "html", textPosition: false }, false).html);
+    }
+
+    return this.tree(bodyParts.join(""), {
+      headHtml: headParts.join(""),
+      htmlAttributes: attributes,
+      htmlNodeIndex: this.emitter.allocate(meta),
+    });
   }
 
   /** A JSX element or fragment, wherever it sits. */
@@ -147,10 +171,10 @@ class JsxAdapter {
       // `<>` is not an element and hides nothing: its children are right here.
       return this.children(node.children, parent, branch);
     }
-    return this.element(node, branch);
+    return this.element(node, parent, branch);
   }
 
-  private element(node: t.JSXElement, branch: boolean): Emitted {
+  private element(node: t.JSXElement, parent: ParentInfo | null, branch: boolean): Emitted {
     const name = elementName(node.openingElement.name);
 
     if (!name.intrinsic) {
@@ -158,24 +182,39 @@ class JsxAdapter {
       // emitted in place, so intrinsic islands inside a component stay
       // auditable. What the component itself renders is unknown here, which is
       // what the parent has to be told.
-      const inner = this.children(node.children, null, branch);
-      return {
-        html: inner.html,
-        unknowable: {
-          kind: "component-child",
-          detail: `<${name.text}> is a component; what it renders is not in this file`,
-          expression: `<${name.text}>`,
-        },
+      const unknowable: Unknowable = {
+        kind: "component-child",
+        detail: `<${name.text}> is a component; what it renders is not in this file`,
+        expression: `<${name.text}>`,
       };
+
+      // Except in a table or a select. There, the component's real output is a
+      // row or an option, and emitting its children in its place puts markup
+      // where an HTML parser will not keep it: a `<h1>` inside `<tbody>` is
+      // foster-parented out, element and text separately, which flattens
+      // everything after it and reports empty headings that are not empty.
+      if (parent && STRICT_CONTENT_TAGS.has(parent.tag)) {
+        return { html: "", unknowable, contentUnknown: unknowable };
+      }
+
+      const inner = this.children(node.children, null, branch);
+      return { html: inner.html, unknowable, contentUnknown: unknowable };
     }
 
     const tag = name.tag;
     const { attributes, meta, textPosition } = this.attributes(node.openingElement, branch, tag);
     const contents = this.children(node.children, { tag, textPosition }, branch);
     if (!meta.unknowableChild) meta.unknowableChild = contents.unknowable;
+    meta.unknownContent = meta.unknowableChild ?? contents.contentUnknown;
 
     const index = this.emitter.allocate(meta);
-    return { html: this.emitter.element(index, tag, attributes, contents.html) };
+    return {
+      html: this.emitter.element(index, tag, attributes, contents.html),
+      // The element itself is a known child of its parent; what is unknown is
+      // what sits inside it, and that carries all the way up because an
+      // accessible name is computed from the whole subtree.
+      contentUnknown: meta.unknownContent,
+    };
   }
 
   private attributes(
@@ -254,6 +293,13 @@ class JsxAdapter {
         });
       } else if (lastSpread >= 0) {
         meta.pinnedAfterSpread.add(name);
+      }
+
+      // A utility class is the other common way a component hides something,
+      // and `hidden` means display:none everywhere it is used. We do not claim
+      // the element *is* hidden — only that we cannot prove it is not.
+      if (name === "class" && resolved.kind === "known" && hidingClass(resolved.value)) {
+        meta.subtreeUnknown = { attribute: "class", expression: resolved.value };
       }
 
       if (resolved.kind === "absent") return;
@@ -378,15 +424,17 @@ class JsxAdapter {
     branch: boolean,
   ): Emitted {
     const parts: string[] = [];
-    let unknowable: NodeMeta["unknowableChild"] | undefined;
+    let unknowable: Unknowable | undefined;
+    let contentUnknown: Unknowable | undefined;
 
     for (const child of children) {
       const emitted = this.child(child, parent, branch);
       parts.push(emitted.html);
       if (!unknowable) unknowable = emitted.unknowable;
+      if (!contentUnknown) contentUnknown = emitted.contentUnknown;
     }
 
-    return { html: parts.join(""), unknowable };
+    return { html: parts.join(""), unknowable, contentUnknown };
   }
 
   private child(
@@ -532,6 +580,7 @@ class JsxAdapter {
     return {
       html: parts.map((part) => part.html).join(""),
       unknowable: parts.find((part) => part.unknowable)?.unknowable,
+      contentUnknown: parts.find((part) => part.contentUnknown)?.contentUnknown,
     };
   }
 
@@ -543,13 +592,13 @@ class JsxAdapter {
    */
   private opaque(node: t.Node, parent: ParentInfo | null): Emitted {
     const expression = this.text(node);
-    const unknowable = {
-      kind: "opaque-expression" as const,
+    const unknowable: Unknowable = {
+      kind: "opaque-expression",
       detail: `\`${expression}\` may render anything`,
       expression,
     };
-    if (parent?.textPosition) return { html: escapeText(TEXT_PLACEHOLDER), unknowable };
-    return { html: "", unknowable };
+    const html = parent?.textPosition ? escapeText(TEXT_PLACEHOLDER) : "";
+    return { html, unknowable, contentUnknown: unknowable };
   }
 
   /** The source text of a node, for the record of what was unknown. */
@@ -565,6 +614,39 @@ class JsxAdapter {
     const text = this.source.slice(node.start, node.end).replace(/\s+/g, " ").trim();
     return text.length > MAX_EXPRESSION_LENGTH ? `${text.slice(0, MAX_EXPRESSION_LENGTH)}…` : text;
   }
+}
+
+/**
+ * Elements whose children an HTML parser will rearrange if they are not the
+ * children it expects. A component sitting in one of these is left unexpanded.
+ */
+const STRICT_CONTENT_TAGS = new Set([
+  "table",
+  "thead",
+  "tbody",
+  "tfoot",
+  "tr",
+  "colgroup",
+  "select",
+  "optgroup",
+]);
+
+/** Utility classes whose whole job is to take the element out of the layout. */
+const HIDING_CLASSES = new Set(["hidden", "invisible"]);
+
+/**
+ * `hidden md:block` is not hidden — it is hidden on a phone and shown from the
+ * md breakpoint up, which is the single most common shape a Tailwind class list
+ * takes. Only an unqualified hide counts, or every responsive column in every
+ * marketing page goes unaudited.
+ */
+const RESHOWN_AT_BREAKPOINT =
+  /^[a-z0-9]+:(block|flex|grid|inline|inline-block|inline-flex|table|table-cell|contents|visible)$/;
+
+function hidingClass(value: string): boolean {
+  const tokens = value.split(/\s+/);
+  if (!tokens.some((token) => HIDING_CLASSES.has(token))) return false;
+  return !tokens.some((token) => RESHOWN_AT_BREAKPOINT.test(token));
 }
 
 function unwrap(node: t.Expression | t.JSXEmptyExpression): t.Expression | t.JSXEmptyExpression {

--- a/source/src/jsx/index.ts
+++ b/source/src/jsx/index.ts
@@ -1,0 +1,694 @@
+import { parse, type ParserOptions } from "@babel/parser";
+import type * as t from "@babel/types";
+import { Emitter, escapeText, type NodeMeta } from "../emit";
+import type { SourceRender } from "../render";
+import {
+  ATTRIBUTE_PLACEHOLDER,
+  SUBTREE_SEMANTICS_ATTRIBUTES,
+  TEXT_ELEMENTS,
+  TEXT_PLACEHOLDER,
+} from "../semantics";
+import { attributeName, CONTENT_PROPS, resolveStyleObject, type StyleResult } from "./attributes";
+
+export interface RenderJsxOptions {
+  /** `.tsx` and `.ts` parse differently from `.jsx`: `<T>` is a type parameter. */
+  typescript?: boolean;
+}
+
+/**
+ * Parse a JSX/TSX file and render its intrinsic elements as HTML.
+ *
+ * Returns null when the file does not parse. That is the package's contract, not
+ * an oversight: a half-understood file must produce no findings rather than
+ * guesses about a tree we did not read.
+ */
+export function renderJsx(source: string, options: RenderJsxOptions = {}): SourceRender | null {
+  const ast = parseJsx(source, options.typescript !== false);
+  if (!ast) return null;
+  return new JsxAdapter(source).render(ast);
+}
+
+type Plugins = NonNullable<ParserOptions["plugins"]>;
+
+const BASE_PLUGINS: Plugins = ["jsx", "decorators-legacy"];
+
+function parseJsx(source: string, typescript: boolean): t.File | null {
+  // TypeScript first for .tsx (the dialect decides), then a plain-JS attempt,
+  // then Flow — a few .jsx files in the wild still carry Flow annotations.
+  const attempts: Plugins[] = typescript
+    ? [[...BASE_PLUGINS, "typescript"], BASE_PLUGINS]
+    : [BASE_PLUGINS, [...BASE_PLUGINS, "flow"], [...BASE_PLUGINS, "typescript"]];
+
+  for (const plugins of attempts) {
+    try {
+      return parse(source, { sourceType: "unambiguous", plugins, ranges: false });
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/** What a child contributes to its parent element beyond markup. */
+interface Emitted {
+  html: string;
+  unknowable?: NodeMeta["unknowableChild"];
+}
+
+/** What a child needs to know about where it sits. */
+interface ParentInfo {
+  tag: string;
+  /**
+   * Whether an expression here produces a name someone reads. True inside a
+   * text-read element or anything carrying a role, and false once the element
+   * is already named by aria-label / aria-labelledby — filling that in buys
+   * nothing and costs a label-content-mismatch against a stand-in word.
+   */
+  textPosition: boolean;
+}
+
+type AttributeValue =
+  | { kind: "known"; value: string }
+  | { kind: "absent" }
+  | { kind: "unknown"; expression: string };
+
+const MAX_EXPRESSION_LENGTH = 120;
+
+class JsxAdapter {
+  private readonly emitter = new Emitter();
+  private hasBranch = false;
+
+  constructor(private readonly source: string) {}
+
+  render(ast: t.File): SourceRender {
+    const headParts: string[] = [];
+    const bodyParts: string[] = [];
+    let htmlAttributes: [string, string][] = [];
+    let htmlNodeIndex: number | null = null;
+
+    const roots = findJsxRoots(ast);
+    for (const root of roots) {
+      if (root.type === "JSXFragment") {
+        bodyParts.push(this.children(root.children, null, false).html);
+        continue;
+      }
+
+      const name = elementName(root.openingElement.name);
+      if (name.intrinsic && name.tag === "html" && htmlNodeIndex === null) {
+        // A root layout's `<html>` is the one page-level shape a component file
+        // can legitimately carry. The document already has an html element, so
+        // this one contributes its attributes to the documentElement and its
+        // head/body children are distributed into the real head and body.
+        const { attributes, meta } = this.attributes(root.openingElement, false, "html");
+        for (const child of root.children) {
+          if (child.type === "JSXElement") {
+            const childName = elementName(child.openingElement.name);
+            if (childName.intrinsic && childName.tag === "head") {
+              headParts.push(
+                this.children(child.children, { tag: "head", textPosition: false }, false).html,
+              );
+              continue;
+            }
+            if (childName.intrinsic && childName.tag === "body") {
+              bodyParts.push(
+                this.children(child.children, { tag: "body", textPosition: false }, false).html,
+              );
+              continue;
+            }
+          }
+          bodyParts.push(this.child(child, { tag: "html", textPosition: false }, false).html);
+        }
+        htmlAttributes = attributes;
+        htmlNodeIndex = this.emitter.allocate(meta);
+        continue;
+      }
+
+      bodyParts.push(this.node(root, null, false).html);
+    }
+
+    return {
+      headHtml: headParts.join(""),
+      bodyHtml: bodyParts.join(""),
+      htmlAttributes,
+      htmlNodeIndex,
+      nodes: this.emitter.nodes,
+      hasBranch: this.hasBranch,
+      rootCount: roots.length,
+    };
+  }
+
+  /** A JSX element or fragment, wherever it sits. */
+  private node(
+    node: t.JSXElement | t.JSXFragment,
+    parent: ParentInfo | null,
+    branch: boolean,
+  ): Emitted {
+    if (node.type === "JSXFragment") {
+      // `<>` is not an element and hides nothing: its children are right here.
+      return this.children(node.children, parent, branch);
+    }
+    return this.element(node, branch);
+  }
+
+  private element(node: t.JSXElement, branch: boolean): Emitted {
+    const name = elementName(node.openingElement.name);
+
+    if (!name.intrinsic) {
+      // Components are transparent: the element vanishes and its children are
+      // emitted in place, so intrinsic islands inside a component stay
+      // auditable. What the component itself renders is unknown here, which is
+      // what the parent has to be told.
+      const inner = this.children(node.children, null, branch);
+      return {
+        html: inner.html,
+        unknowable: {
+          kind: "component-child",
+          detail: `<${name.text}> is a component; what it renders is not in this file`,
+          expression: `<${name.text}>`,
+        },
+      };
+    }
+
+    const tag = name.tag;
+    const { attributes, meta, textPosition } = this.attributes(node.openingElement, branch, tag);
+    const contents = this.children(node.children, { tag, textPosition }, branch);
+    if (!meta.unknowableChild) meta.unknowableChild = contents.unknowable;
+
+    const index = this.emitter.allocate(meta);
+    return { html: this.emitter.element(index, tag, attributes, contents.html) };
+  }
+
+  private attributes(
+    open: t.JSXOpeningElement,
+    branch: boolean,
+    tag: string,
+  ): { attributes: [string, string][]; meta: NodeMeta; textPosition: boolean } {
+    const meta: NodeMeta = {
+      line: open.loc?.start.line ?? 1,
+      column: (open.loc?.start.column ?? 0) + 1,
+      tag,
+      unknownAttributes: new Map(),
+      pinnedAfterSpread: new Set(),
+      branch,
+    };
+
+    const attributes: [string, string][] = [];
+    let hasRole = false;
+    let named = false;
+
+    // The ordering calculus: an attribute's value is known only when no later
+    // spread can override it, and its *absence* is never provable once any
+    // spread is present.
+    let lastSpread = -1;
+    open.attributes.forEach((attribute, index) => {
+      if (attribute.type === "JSXSpreadAttribute") lastSpread = index;
+    });
+
+    open.attributes.forEach((attribute, index) => {
+      if (attribute.type === "JSXSpreadAttribute") {
+        meta.spread = { expression: this.text(attribute.argument) };
+        return;
+      }
+
+      const prop =
+        attribute.name.type === "JSXNamespacedName"
+          ? `${attribute.name.namespace.name}:${attribute.name.name.name}`
+          : attribute.name.name;
+
+      if (CONTENT_PROPS.has(prop)) {
+        // `dangerouslySetInnerHTML` and `children={...}` are markup we cannot
+        // read, so the element's contents are unknown.
+        meta.unknowableChild = {
+          kind: "opaque-expression",
+          detail: `${prop} supplies contents this file does not describe`,
+          expression: this.text(attribute),
+        };
+        return;
+      }
+
+      const name = attributeName(prop);
+      if (name === null) return;
+
+      const resolved =
+        name === "style" ? this.styleValue(attribute) : this.attributeValue(attribute);
+
+      if (name === "aria-label" || name === "aria-labelledby") named = true;
+
+      const overridable = index < lastSpread;
+      if (name === "role" && resolved.kind === "known" && resolved.value.trim() && !overridable) {
+        hasRole = true;
+      }
+
+      if (resolved.kind === "unknown") {
+        meta.unknownAttributes.set(name, {
+          expression: resolved.expression,
+          cause: "expression",
+        });
+        if (SUBTREE_SEMANTICS_ATTRIBUTES.has(name)) {
+          meta.subtreeUnknown = { attribute: name, expression: resolved.expression };
+        }
+      } else if (overridable) {
+        meta.unknownAttributes.set(name, {
+          expression: this.spreadAfter(open, index),
+          cause: "spread",
+        });
+      } else if (lastSpread >= 0) {
+        meta.pinnedAfterSpread.add(name);
+      }
+
+      if (resolved.kind === "absent") return;
+      attributes.push([name, resolved.kind === "known" ? resolved.value : ATTRIBUTE_PLACEHOLDER]);
+    });
+
+    return {
+      attributes,
+      meta,
+      textPosition: (TEXT_ELEMENTS.has(tag) || hasRole) && !named,
+    };
+  }
+
+  /** The first spread written after this attribute — the one that can override it. */
+  private spreadAfter(open: t.JSXOpeningElement, index: number): string {
+    const spread = open.attributes
+      .slice(index + 1)
+      .find((attribute) => attribute.type === "JSXSpreadAttribute");
+    return spread ? this.text((spread as t.JSXSpreadAttribute).argument) : "";
+  }
+
+  private attributeValue(attribute: t.JSXAttribute): AttributeValue {
+    const value = attribute.value;
+    // `<input disabled />` — present, empty value.
+    if (value === null || value === undefined) return { kind: "known", value: "" };
+    if (value.type === "StringLiteral") return { kind: "known", value: value.value };
+    if (value.type === "JSXElement" || value.type === "JSXFragment") {
+      return { kind: "unknown", expression: this.text(value) };
+    }
+    if (value.type !== "JSXExpressionContainer") {
+      return { kind: "unknown", expression: this.text(value) };
+    }
+    return this.expressionValue(value.expression);
+  }
+
+  private expressionValue(node: t.Expression | t.JSXEmptyExpression): AttributeValue {
+    const expression = unwrap(node);
+    switch (expression.type) {
+      case "StringLiteral":
+        return { kind: "known", value: expression.value };
+      case "NumericLiteral":
+        return { kind: "known", value: String(expression.value) };
+      // `tabIndex={-1}` is a unary minus over a literal, not a literal.
+      case "UnaryExpression":
+        if (
+          (expression.operator === "-" || expression.operator === "+") &&
+          expression.argument.type === "NumericLiteral"
+        ) {
+          return {
+            kind: "known",
+            value: `${expression.operator === "-" ? "-" : ""}${expression.argument.value}`,
+          };
+        }
+        return { kind: "unknown", expression: this.text(expression) };
+      case "BooleanLiteral":
+        // React omits a false-valued attribute entirely, and that is provable.
+        return expression.value ? { kind: "known", value: "" } : { kind: "absent" };
+      case "NullLiteral":
+        return { kind: "absent" };
+      case "Identifier":
+        if (expression.name === "undefined") return { kind: "absent" };
+        return { kind: "unknown", expression: this.text(expression) };
+      case "TemplateLiteral":
+        if (expression.expressions.length === 0) {
+          return { kind: "known", value: expression.quasis.map((q) => q.value.cooked).join("") };
+        }
+        return { kind: "unknown", expression: this.text(expression) };
+      default:
+        return { kind: "unknown", expression: this.text(expression) };
+    }
+  }
+
+  private styleValue(attribute: t.JSXAttribute): AttributeValue {
+    const value = attribute.value;
+    if (value?.type === "StringLiteral") return { kind: "known", value: value.value };
+    if (value?.type !== "JSXExpressionContainer") {
+      return { kind: "unknown", expression: this.text(attribute) };
+    }
+    const expression = unwrap(value.expression);
+    if (expression.type === "StringLiteral") return { kind: "known", value: expression.value };
+    if (expression.type !== "ObjectExpression") {
+      return { kind: "unknown", expression: this.text(expression) };
+    }
+
+    let hasSpread = false;
+    const properties = expression.properties.map((property) => {
+      if (property.type !== "ObjectProperty") {
+        hasSpread = true;
+        return { property: null, literal: null };
+      }
+      const key =
+        property.key.type === "Identifier"
+          ? property.key.name
+          : property.key.type === "StringLiteral"
+            ? property.key.value
+            : null;
+      const declared = unwrap(property.value as t.Expression);
+      const literal =
+        declared.type === "StringLiteral"
+          ? declared.value
+          : declared.type === "NumericLiteral"
+            ? String(declared.value)
+            : null;
+      return { property: key, literal };
+    });
+
+    const style: StyleResult = resolveStyleObject(properties, hasSpread);
+    if (style.kind === "unknown") return { kind: "unknown", expression: this.text(expression) };
+    if (!style.css) return { kind: "absent" };
+    return { kind: "known", value: style.css };
+  }
+
+  private children(
+    children: (
+      | t.JSXElement
+      | t.JSXFragment
+      | t.JSXText
+      | t.JSXExpressionContainer
+      | t.JSXSpreadChild
+    )[],
+    parent: ParentInfo | null,
+    branch: boolean,
+  ): Emitted {
+    const parts: string[] = [];
+    let unknowable: NodeMeta["unknowableChild"] | undefined;
+
+    for (const child of children) {
+      const emitted = this.child(child, parent, branch);
+      parts.push(emitted.html);
+      if (!unknowable) unknowable = emitted.unknowable;
+    }
+
+    return { html: parts.join(""), unknowable };
+  }
+
+  private child(
+    child: t.JSXElement | t.JSXFragment | t.JSXText | t.JSXExpressionContainer | t.JSXSpreadChild,
+    parent: ParentInfo | null,
+    branch: boolean,
+  ): Emitted {
+    switch (child.type) {
+      case "JSXText":
+        return { html: jsxText(child.value) };
+      case "JSXElement":
+      case "JSXFragment":
+        return this.node(child, parent, branch);
+      case "JSXExpressionContainer":
+        return this.expression(child.expression, parent, branch);
+      case "JSXSpreadChild":
+        return this.opaque(child.expression, parent);
+    }
+  }
+
+  /**
+   * The three-tier expression model. Tier 1 is a literal, used as written. Tier
+   * 2 is JSX inside an expression — a `.map` callback, a ternary arm, the right
+   * of `&&` — which is walked into and emitted, because `items.map(i => <div/>)`
+   * inside a `<ul>` is a provable runtime defect. Tier 3 is opaque: silence,
+   * except for a stand-in in text position.
+   */
+  private expression(
+    node: t.Expression | t.JSXEmptyExpression,
+    parent: ParentInfo | null,
+    branch: boolean,
+  ): Emitted {
+    const expression = unwrap(node);
+
+    switch (expression.type) {
+      // `{/* a comment */}` renders nothing, and hides nothing.
+      case "JSXEmptyExpression":
+        return { html: "" };
+      case "JSXElement":
+      case "JSXFragment":
+        return this.node(expression, parent, branch);
+      case "StringLiteral":
+        return { html: escapeText(expression.value) };
+      case "NumericLiteral":
+        return { html: escapeText(String(expression.value)) };
+      case "TemplateLiteral":
+        if (expression.expressions.length === 0) {
+          return { html: escapeText(expression.quasis.map((q) => q.value.cooked).join("")) };
+        }
+        return this.opaque(expression, parent);
+      // React renders none of these, which is knowable.
+      case "BooleanLiteral":
+      case "NullLiteral":
+        return { html: "" };
+      case "Identifier":
+        if (expression.name === "undefined") return { html: "" };
+        return this.opaque(expression, parent);
+
+      case "ConditionalExpression": {
+        // Both arms are emitted, so the elements are real but the order is not.
+        this.hasBranch = true;
+        return this.combine([
+          this.expression(expression.consequent, parent, true),
+          this.expression(expression.alternate, parent, true),
+        ]);
+      }
+
+      case "LogicalExpression": {
+        this.hasBranch = true;
+        const arms =
+          expression.operator === "&&"
+            ? [this.expression(expression.right as t.Expression, parent, true)]
+            : [
+                this.expression(expression.left as t.Expression, parent, true),
+                this.expression(expression.right as t.Expression, parent, true),
+              ];
+        return this.combine(arms);
+      }
+
+      case "ArrayExpression": {
+        const arms = expression.elements.map((element) =>
+          element === null || element.type === "SpreadElement"
+            ? this.opaque(element ?? expression, parent)
+            : this.expression(element as t.Expression, parent, branch),
+        );
+        return this.combine(arms);
+      }
+
+      case "CallExpression":
+        return this.call(expression, parent, branch);
+
+      default:
+        return this.opaque(expression, parent);
+    }
+  }
+
+  /**
+   * `items.map(item => <li>…</li>)` is the shape almost every list in a React
+   * component takes. The callback's return value is what lands in the DOM, so
+   * walking into it is what lets container rules stay on: a `<div>` returned
+   * into a `<ul>` is a defect whatever `items` holds. Iteration is repetition,
+   * not exclusivity, so a single-return callback is not a branch.
+   */
+  private call(node: t.CallExpression, parent: ParentInfo | null, branch: boolean): Emitted {
+    const callee = node.callee;
+    const method =
+      callee.type === "MemberExpression" && callee.property.type === "Identifier"
+        ? callee.property.name
+        : null;
+    if (method !== "map" && method !== "flatMap") return this.opaque(node, parent);
+
+    const callback = node.arguments[0];
+    if (
+      !callback ||
+      (callback.type !== "ArrowFunctionExpression" && callback.type !== "FunctionExpression")
+    ) {
+      return this.opaque(node, parent);
+    }
+
+    return this.returns(callback, parent, branch);
+  }
+
+  private returns(
+    callback: t.ArrowFunctionExpression | t.FunctionExpression,
+    parent: ParentInfo | null,
+    branch: boolean,
+  ): Emitted {
+    if (callback.body.type !== "BlockStatement") {
+      return this.expression(callback.body, parent, branch);
+    }
+
+    const returned = returnedExpressions(callback.body);
+    if (returned.length === 0) return { html: "" };
+    // More than one return is a branch: only one of them ever renders.
+    const exclusive = returned.length > 1;
+    if (exclusive) this.hasBranch = true;
+    return this.combine(
+      returned.map((expression) => this.expression(expression, parent, branch || exclusive)),
+    );
+  }
+
+  private combine(parts: Emitted[]): Emitted {
+    return {
+      html: parts.map((part) => part.html).join(""),
+      unknowable: parts.find((part) => part.unknowable)?.unknowable,
+    };
+  }
+
+  /**
+   * Tier 3. The element's contents become unknown, which silences every rule
+   * that reads them; and where text is what an element is read for, a stand-in
+   * word stands in for it — the trade the ERB neutralizer settled, for the same
+   * reason. A missing name is reported, a stray text node is not.
+   */
+  private opaque(node: t.Node, parent: ParentInfo | null): Emitted {
+    const expression = this.text(node);
+    const unknowable = {
+      kind: "opaque-expression" as const,
+      detail: `\`${expression}\` may render anything`,
+      expression,
+    };
+    if (parent?.textPosition) return { html: escapeText(TEXT_PLACEHOLDER), unknowable };
+    return { html: "", unknowable };
+  }
+
+  /** The source text of a node, for the record of what was unknown. */
+  private text(node: t.Node): string {
+    if (
+      node.start === null ||
+      node.start === undefined ||
+      node.end === null ||
+      node.end === undefined
+    ) {
+      return "";
+    }
+    const text = this.source.slice(node.start, node.end).replace(/\s+/g, " ").trim();
+    return text.length > MAX_EXPRESSION_LENGTH ? `${text.slice(0, MAX_EXPRESSION_LENGTH)}…` : text;
+  }
+}
+
+function unwrap(node: t.Expression | t.JSXEmptyExpression): t.Expression | t.JSXEmptyExpression {
+  let current = node;
+  for (;;) {
+    switch (current.type) {
+      case "TSAsExpression":
+      case "TSSatisfiesExpression":
+      case "TSNonNullExpression":
+      case "TSTypeAssertion":
+      case "TypeCastExpression":
+      case "ParenthesizedExpression":
+        current = current.expression;
+        break;
+      default:
+        return current;
+    }
+  }
+}
+
+/**
+ * JSX drops whitespace-only text that spans lines and collapses interior
+ * newline runs to a single space — the indentation in a component file is not
+ * content.
+ */
+function jsxText(raw: string): string {
+  if (/^\s*$/.test(raw)) return raw.includes("\n") ? "" : escapeText(raw);
+  const trimmed = raw.replace(/^[ \t]*\n\s*/, "").replace(/\s*\n[ \t]*$/, "");
+  return escapeText(trimmed.replace(/\s*\n\s*/g, " "));
+}
+
+interface ElementName {
+  intrinsic: boolean;
+  tag: string;
+  text: string;
+}
+
+/**
+ * JSX's own rule: a lowercase name is an intrinsic element, anything else is a
+ * component. A namespaced name (`<svg:circle>`) is intrinsic; a member
+ * expression (`<Card.Header>`) never is.
+ */
+function elementName(name: t.JSXOpeningElement["name"]): ElementName {
+  if (name.type === "JSXIdentifier") {
+    const intrinsic = /^[a-z]/.test(name.name);
+    return { intrinsic, tag: name.name.toLowerCase(), text: name.name };
+  }
+  if (name.type === "JSXNamespacedName") {
+    const text = `${name.namespace.name}:${name.name.name}`;
+    return { intrinsic: true, tag: text.toLowerCase(), text };
+  }
+  return { intrinsic: false, tag: "", text: memberName(name) };
+}
+
+function memberName(name: t.JSXMemberExpression): string {
+  const object =
+    name.object.type === "JSXMemberExpression" ? memberName(name.object) : name.object.name;
+  return `${object}.${name.property.name}`;
+}
+
+/** Return statements in a function body, not descending into nested functions. */
+function returnedExpressions(body: t.BlockStatement): t.Expression[] {
+  const found: t.Expression[] = [];
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    const type = (node as { type?: string }).type;
+    if (!type) return;
+    if (type.endsWith("FunctionExpression") || type === "FunctionDeclaration") return;
+    if (type === "ReturnStatement") {
+      const argument = (node as t.ReturnStatement).argument;
+      if (argument) found.push(argument);
+      return;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (SKIPPED_AST_KEYS.has(key)) continue;
+      visit(value);
+    }
+  };
+  visit(body.body);
+  return found;
+}
+
+const SKIPPED_AST_KEYS = new Set([
+  "loc",
+  "start",
+  "end",
+  "range",
+  "extra",
+  "comments",
+  "leadingComments",
+  "trailingComments",
+  "innerComments",
+  "tokens",
+]);
+
+/**
+ * Every JSX element or fragment with no JSX ancestor, in source order. A file
+ * with several components contributes several roots; they land as siblings,
+ * which is safe because source mode never asks a page-level or cross-element
+ * idref question.
+ */
+function findJsxRoots(ast: t.File): (t.JSXElement | t.JSXFragment)[] {
+  const roots: (t.JSXElement | t.JSXFragment)[] = [];
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    const type = (node as { type?: string }).type;
+    if (!type) return;
+    if (type === "JSXElement" || type === "JSXFragment") {
+      roots.push(node as t.JSXElement | t.JSXFragment);
+      return;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (SKIPPED_AST_KEYS.has(key)) continue;
+      visit(value);
+    }
+  };
+  visit(ast.program.body);
+  return roots;
+}

--- a/source/src/jsx/render.test.ts
+++ b/source/src/jsx/render.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { MARKER_ATTRIBUTE } from "../emit";
+import { renderJsx } from "./index";
+
+function body(source: string): string {
+  const render = renderJsx(source, { typescript: true });
+  expect(render).not.toBeNull();
+  // The marker attribute is what the audit layer strips; drop it here so these
+  // assertions read as the HTML the engine parses.
+  return render!.bodyHtml.replace(new RegExp(` ?${MARKER_ATTRIBUTE}="\\d+"`, "g"), "");
+}
+
+describe("attributes", () => {
+  it("renames the props that are not attribute names", () => {
+    expect(body(`const A = <label className="lbl" htmlFor="name" />;`)).toBe(
+      `<label class="lbl" for="name"></label>`,
+    );
+  });
+
+  it("lowercases camelCase attributes", () => {
+    expect(body(`const A = <input readOnly maxLength={10} tabIndex={-1} />;`)).toBe(
+      `<input readonly="" maxlength="10" tabindex="-1" />`,
+    );
+  });
+
+  it("drops event handlers and React-only props", () => {
+    expect(body(`const A = <button key="a" ref={r} onClick={go}>Go</button>;`)).toBe(
+      `<button>Go</button>`,
+    );
+  });
+
+  it("omits an attribute React would not render", () => {
+    expect(body(`const A = <input disabled={false} required={true} />;`)).toBe(
+      `<input required="" />`,
+    );
+  });
+
+  it("stands in for an expression-valued attribute", () => {
+    expect(body(`const A = <img src={url} alt={label} />;`)).toBe(
+      `<img src="unknown" alt="unknown" />`,
+    );
+  });
+
+  it("resolves a literal style object and keeps what can hide an element", () => {
+    expect(body(`const A = <div style={{ display: "none", marginTop: 4 }} />;`)).toBe(
+      `<div style="display: none; margin-top: 4"></div>`,
+    );
+  });
+
+  it("keeps the literal half of a style object whose other values cannot hide", () => {
+    expect(body(`const A = <div style={{ width: w, color: "red" }} />;`)).toBe(
+      `<div style="color: red"></div>`,
+    );
+  });
+});
+
+describe("children", () => {
+  it("drops JSX indentation but keeps real text", () => {
+    expect(
+      body(`const A = (
+        <p>
+          Hello
+          world
+        </p>
+      );`),
+    ).toBe(`<p>Hello world</p>`);
+  });
+
+  it("emits a fragment's children without a wrapper", () => {
+    expect(body(`const A = <><span>a</span><span>b</span></>;`)).toBe(
+      `<span>a</span><span>b</span>`,
+    );
+  });
+
+  it("emits a component's children in place", () => {
+    expect(body(`const A = <Card><img src="/a.png" /></Card>;`)).toBe(`<img src="/a.png" />`);
+  });
+
+  it("walks into a map callback", () => {
+    expect(body(`const A = <ul>{items.map((i) => <li>{i.name}</li>)}</ul>;`)).toBe(
+      `<ul><li>Text</li></ul>`,
+    );
+  });
+
+  it("emits both arms of a ternary", () => {
+    const render = renderJsx(`const A = <div>{on ? <b>on</b> : <i>off</i>}</div>;`, {
+      typescript: true,
+    });
+    expect(render?.hasBranch).toBe(true);
+    expect(body(`const A = <div>{on ? <b>on</b> : <i>off</i>}</div>;`)).toBe(
+      `<div><b>on</b><i>off</i></div>`,
+    );
+  });
+
+  it("emits the right side of a logical and", () => {
+    expect(body(`const A = <div>{open && <span>yes</span>}</div>;`)).toBe(
+      `<div><span>yes</span></div>`,
+    );
+  });
+
+  it("renders nothing for a comment", () => {
+    expect(body(`const A = <div>{/* nothing here */}</div>;`)).toBe(`<div></div>`);
+  });
+
+  it("stands in for an opaque expression only where text is read", () => {
+    expect(body(`const A = <h1>{title}</h1>;`)).toBe(`<h1>Text</h1>`);
+    expect(body(`const A = <ul>{rows}</ul>;`)).toBe(`<ul></ul>`);
+  });
+
+  it("does not stand in for an element that is already named", () => {
+    expect(body(`const A = <button aria-label="Close">{icon}</button>;`)).toBe(
+      `<button aria-label="Close"></button>`,
+    );
+  });
+
+  it("escapes text, and leaves a decoded entity as the character it is", () => {
+    expect(body(`const A = <p>{"a < b & c"}</p>;`)).toBe(`<p>a &lt; b &amp; c</p>`);
+    // The parser decodes JSX entities, so what reaches the DOM is the character.
+    expect(body(`const A = <p>a&nbsp;b</p>;`)).toBe(`<p>a\u00a0b</p>`);
+  });
+});
+
+describe("the node table", () => {
+  it("carries the source position of every element", () => {
+    const render = renderJsx(
+      `export const A = () => (
+  <div>
+    <img src="/a.png" />
+  </div>
+);`,
+      { typescript: true },
+    );
+    const img = render?.nodes.find((node) => node.tag === "img");
+    expect(img?.line).toBe(3);
+    expect(img?.column).toBe(5);
+  });
+
+  it("records a spread and what it could override", () => {
+    const render = renderJsx(`const A = <img alt="" {...rest} src="/a.png" />;`, {
+      typescript: true,
+    });
+    const img = render?.nodes[0];
+    expect(img?.spread?.expression).toBe("rest");
+    expect(img?.unknownAttributes.get("alt")?.cause).toBe("spread");
+    expect(img?.pinnedAfterSpread.has("src")).toBe(true);
+  });
+
+  it("records dangerouslySetInnerHTML as unknown contents", () => {
+    const render = renderJsx(`const A = <div dangerouslySetInnerHTML={{ __html: raw }} />;`, {
+      typescript: true,
+    });
+    expect(render?.nodes[0]?.unknowableChild?.kind).toBe("opaque-expression");
+  });
+});
+
+describe("a root layout", () => {
+  it("lifts the html element's attributes out of the body", () => {
+    const render = renderJsx(
+      `export default function Layout({ children }) {
+  return (
+    <html lang="en">
+      <head><title>Site</title></head>
+      <body>{children}</body>
+    </html>
+  );
+}`,
+      { typescript: true },
+    );
+
+    expect(render?.htmlAttributes).toEqual([["lang", "en"]]);
+    expect(render?.headHtml).toContain("<title");
+    // `{children}` in a `<body>` is markup, not a name: nothing stands in for it.
+    expect(render?.bodyHtml).toBe("");
+    expect(render?.nodes[render!.htmlNodeIndex!]?.tag).toBe("html");
+  });
+});
+
+describe("parse failures", () => {
+  it("returns null rather than guessing", () => {
+    expect(renderJsx(`const A = <div>`, { typescript: true })).toBeNull();
+  });
+
+  it("reads a Flow-annotated .jsx file", () => {
+    const render = renderJsx(`type Props = { a: number };\nconst A = () => <div />;`, {
+      typescript: false,
+    });
+    expect(render?.nodes[0]?.tag).toBe("div");
+  });
+});

--- a/source/src/jsx/render.test.ts
+++ b/source/src/jsx/render.test.ts
@@ -7,7 +7,16 @@ function body(source: string): string {
   expect(render).not.toBeNull();
   // The marker attribute is what the audit layer strips; drop it here so these
   // assertions read as the HTML the engine parses.
-  return render!.bodyHtml.replace(new RegExp(` ?${MARKER_ATTRIBUTE}="\\d+"`, "g"), "");
+  return render!.trees
+    .map((tree) => tree.bodyHtml)
+    .join("")
+    .replace(new RegExp(` ?${MARKER_ATTRIBUTE}="\\d+"`, "g"), "");
+}
+
+function tree(source: string) {
+  const render = renderJsx(source, { typescript: true });
+  expect(render).not.toBeNull();
+  return render!.trees[0];
 }
 
 describe("attributes", () => {
@@ -83,10 +92,7 @@ describe("children", () => {
   });
 
   it("emits both arms of a ternary", () => {
-    const render = renderJsx(`const A = <div>{on ? <b>on</b> : <i>off</i>}</div>;`, {
-      typescript: true,
-    });
-    expect(render?.hasBranch).toBe(true);
+    expect(tree(`const A = <div>{on ? <b>on</b> : <i>off</i>}</div>;`).hasBranch).toBe(true);
     expect(body(`const A = <div>{on ? <b>on</b> : <i>off</i>}</div>;`)).toBe(
       `<div><b>on</b><i>off</i></div>`,
     );
@@ -167,11 +173,12 @@ describe("a root layout", () => {
       { typescript: true },
     );
 
-    expect(render?.htmlAttributes).toEqual([["lang", "en"]]);
-    expect(render?.headHtml).toContain("<title");
+    const layout = render!.trees[0];
+    expect(layout.htmlAttributes).toEqual([["lang", "en"]]);
+    expect(layout.headHtml).toContain("<title");
     // `{children}` in a `<body>` is markup, not a name: nothing stands in for it.
-    expect(render?.bodyHtml).toBe("");
-    expect(render?.nodes[render!.htmlNodeIndex!]?.tag).toBe("html");
+    expect(layout.bodyHtml).toBe("");
+    expect(render?.nodes[layout.htmlNodeIndex!]?.tag).toBe("html");
   });
 });
 

--- a/source/src/render.ts
+++ b/source/src/render.ts
@@ -1,27 +1,82 @@
 import type { NodeMeta } from "./emit";
 
 /**
- * What a dialect adapter produces: the synthetic document, plus the node table
- * that maps every emitted element back to the source and to what the source
- * left unknown.
+ * One JSX root, rendered. Each is audited in a document of its own, and that is
+ * not tidiness — it is correctness.
+ *
+ * A file's roots are independent trees: two components never coexist on a page.
+ * Concatenating them into one body also hands the HTML parser a sequence it is
+ * entitled to rearrange — a component returning `<tr>` puts the parser in table
+ * mode, and every element after it gets foster-parented out of its own parent,
+ * text and all. A docusaurus page audited that way reported an empty `<h1>`, an
+ * empty `<button>`, and a link with no text, none of which were true.
  */
-export interface SourceRender {
+export interface SourceTree {
   /** Contents of `<head>`, from a literal intrinsic `<html><head>` only. */
   headHtml: string;
-  /** Everything else, in source order. */
   bodyHtml: string;
   /** Attributes of a literal intrinsic `<html>`, applied to the documentElement. */
   htmlAttributes: [string, string][];
-  /** Node-table index of a literal intrinsic `<html>`, when the file has one. */
+  /** Node-table index of a literal intrinsic `<html>`, when this root is one. */
   htmlNodeIndex: number | null;
-  nodes: NodeMeta[];
-  /** True when the file emits elements from exclusive branches. */
-  hasBranch: boolean;
   /**
-   * How many independent JSX trees the file contributed. Two components in one
-   * file land as siblings and never coexist on a page, which is the same hazard
-   * a branch is: an `<h1>` in one and an `<h3>` in the other is not a heading
-   * order.
+   * The ancestors this fragment needs before an HTML parser will accept it. A
+   * `<tr>` on its own is dropped; wrapped in `<table><tbody>` it survives intact.
+   * Set means the container around the fragment is ours, not the author's, so no
+   * rule may reason about it.
    */
-  rootCount: number;
+  wrapper: TableWrapper | null;
+  /** True when this root emits elements from exclusive branches. */
+  hasBranch: boolean;
+}
+
+export type TableWrapper = "row" | "cell" | "section" | "column" | "option";
+
+/**
+ * What a dialect adapter produces: one tree per JSX root, plus the node table
+ * that maps every emitted element back to the source and to what the source left
+ * unknown.
+ */
+export interface SourceRender {
+  trees: SourceTree[];
+  nodes: NodeMeta[];
+}
+
+/** The minimal legal ancestors for a fragment that starts with a table part. */
+const WRAPPERS: Record<TableWrapper, { open: string; close: string }> = {
+  row: { open: "<table><tbody>", close: "</tbody></table>" },
+  cell: { open: "<table><tbody><tr>", close: "</tr></tbody></table>" },
+  section: { open: "<table>", close: "</table>" },
+  column: { open: "<table><colgroup>", close: "</colgroup></table>" },
+  option: { open: "<select>", close: "</select>" },
+};
+
+const WRAPPER_FOR_TAG: Record<string, TableWrapper> = {
+  tr: "row",
+  td: "cell",
+  th: "cell",
+  thead: "section",
+  tbody: "section",
+  tfoot: "section",
+  caption: "section",
+  colgroup: "section",
+  col: "column",
+  option: "option",
+  optgroup: "option",
+};
+
+/**
+ * The wrapper a fragment needs, decided by the tag it opens with — which is the
+ * shape that actually occurs: a component whose whole job is to render one row
+ * or one cell.
+ */
+export function wrapperFor(bodyHtml: string): TableWrapper | null {
+  const match = /^<([a-z][a-z0-9-]*)\b/.exec(bodyHtml);
+  return match ? (WRAPPER_FOR_TAG[match[1]] ?? null) : null;
+}
+
+export function wrapped(tree: SourceTree): string {
+  if (!tree.wrapper) return tree.bodyHtml;
+  const { open, close } = WRAPPERS[tree.wrapper];
+  return `${open}${tree.bodyHtml}${close}`;
 }

--- a/source/src/render.ts
+++ b/source/src/render.ts
@@ -1,0 +1,27 @@
+import type { NodeMeta } from "./emit";
+
+/**
+ * What a dialect adapter produces: the synthetic document, plus the node table
+ * that maps every emitted element back to the source and to what the source
+ * left unknown.
+ */
+export interface SourceRender {
+  /** Contents of `<head>`, from a literal intrinsic `<html><head>` only. */
+  headHtml: string;
+  /** Everything else, in source order. */
+  bodyHtml: string;
+  /** Attributes of a literal intrinsic `<html>`, applied to the documentElement. */
+  htmlAttributes: [string, string][];
+  /** Node-table index of a literal intrinsic `<html>`, when the file has one. */
+  htmlNodeIndex: number | null;
+  nodes: NodeMeta[];
+  /** True when the file emits elements from exclusive branches. */
+  hasBranch: boolean;
+  /**
+   * How many independent JSX trees the file contributed. Two components in one
+   * file land as siblings and never coexist on a page, which is the same hazard
+   * a branch is: an `<h1>` in one and an `<h3>` in the other is not a heading
+   * order.
+   */
+  rootCount: number;
+}

--- a/source/src/scope.ts
+++ b/source/src/scope.ts
@@ -1,0 +1,69 @@
+// Which files source mode has anything true to say about.
+//
+// Both checks here came out of the corpus triage, and both are the same kind of
+// judgement: a finding has to be a defect a user could hit. JSX that never
+// becomes a DOM cannot produce one, and a fixture built to hold broken markup is
+// not a defect either — it is the test's subject.
+
+/**
+ * Modules that consume JSX and render something other than a document. Satori
+ * and its wrappers are the ones that matter: they deliberately accept `div`,
+ * `img`, `p` and `span` and turn them into a PNG, so an `<img>` there has no alt
+ * to miss and no accessibility tree to be missing from.
+ */
+const NON_DOM_MODULES =
+  /(^|[/'"])(satori|@vercel\/og|next\/og|og_edge|@react-pdf\/renderer|react-nil)(['"/]|$)/;
+
+/** `import { ImageResponse } from …` — the satori entry point under every name. */
+const IMAGE_RESPONSE_IMPORT = /import\s*\{[^}]*\bImageResponse\b[^}]*\}\s*from/;
+
+/**
+ * Next's metadata file convention: these modules export an image, never a page.
+ * Matched loosely because the same file gets hand-rolled under near-miss names
+ * (`open-graph-image.tsx` next to Next's own `opengraph-image.tsx`).
+ */
+const IMAGE_MODULE_FILENAME =
+  /(^|\/)(opengraph-image|open-graph-image|twitter-image|apple-icon|icon)([.-][^/]*)?\.(jsx|tsx)$/;
+
+/** satori's Tailwind prop. Not an HTML attribute, and nothing else uses it. */
+const SATORI_TAILWIND_PROP = /\stw=["{]/;
+
+/**
+ * A file whose JSX is rendered by something other than a DOM. Findings from one
+ * would be about markup no user ever reaches.
+ *
+ * The `tw` attribute is the third tell and the one that catches satori's
+ * *component* files, where the `ImageResponse` call lives in a sibling module:
+ * `tw` is not an HTML attribute, it is satori's Tailwind prop.
+ */
+export function nonDomRenderer(source: string, filename?: string): boolean {
+  if (filename && IMAGE_MODULE_FILENAME.test(filename)) return true;
+  if (IMAGE_RESPONSE_IMPORT.test(source)) return true;
+  if (SATORI_TAILWIND_PROP.test(source)) return true;
+  for (const line of source.split("\n")) {
+    if (!/^\s*(import|export)\b/.test(line) && !/\brequire\(/.test(line)) continue;
+    if (NON_DOM_MODULES.test(line)) return true;
+  }
+  return false;
+}
+
+/**
+ * Test files and fixtures. Their markup is written to be wrong — a positive
+ * `tabIndex` fixture in a focus-trap test suite is the test, not a defect — so a
+ * review comment on one is noise of exactly the kind that gets a bot ignored.
+ * Stories and playground apps are *not* included: those are real UI.
+ */
+const TEST_FILENAME = /(^|\/)[^/]*\.(test|spec)\.(jsx|tsx)$/;
+const TEST_DIRECTORIES = new Set([
+  "__tests__",
+  "__mocks__",
+  "__fixtures__",
+  "fixtures",
+  "test-fixtures",
+]);
+
+export function testFile(filename?: string): boolean {
+  if (!filename) return false;
+  if (TEST_FILENAME.test(filename)) return true;
+  return filename.split("/").some((segment) => TEST_DIRECTORIES.has(segment));
+}

--- a/source/src/semantics.ts
+++ b/source/src/semantics.ts
@@ -31,6 +31,11 @@ export const SOURCE_MODE_DISABLED_RULES = [
   "distinguishable/word-spacing",
   "keyboard-accessible/scrollable-region",
   "keyboard-accessible/focus-visible",
+  // A `<div tabindex="0">` is either a keyboard-reachable scroll container — the
+  // recommended pattern — or a control built out of a div. Which one it is
+  // depends on whether the element scrolls, and that is a layout fact. Same
+  // gap as scrollable-region above, so the same answer.
+  "keyboard-accessible/focus-order",
   "aria/aria-hidden-focus",
   "landmarks/region",
   // Cross-element idref
@@ -69,10 +74,23 @@ export const FRAGMENT_DISABLED_RULES = [
 export const HTML_ELEMENT_RULE = "readable/html-has-lang";
 
 /**
+ * Container integrity: these read an element's *direct* children and nothing
+ * deeper, so only a direct unknown child silences them. A `<div>` mapped into a
+ * `<ul>` is still a finding when the `<div>`'s own contents are unknown — the
+ * defect is where the div sits, not what it holds.
+ */
+export const DIRECT_CHILD_RULES = new Set([
+  "adaptable/list-children",
+  "adaptable/definition-list",
+  "adaptable/aria-required-children",
+]);
+
+/**
  * Rules whose verdict depends on what an element *contains* — container
  * integrity, and every name-from-content rule. A component child or an opaque
  * expression child makes the contents unknown, so these go silent for that
- * element.
+ * element. All but DIRECT_CHILD_RULES read the whole subtree: an accessible name
+ * comes from any descendant, and a table's cells are not its children.
  */
 export const CHILD_DEPENDENT_RULES = new Set([
   "adaptable/list-children",
@@ -101,11 +119,20 @@ export const CHILD_DEPENDENT_RULES = new Set([
  * container, and where the container is. `list-children` reports the stray
  * `<div>`, not the `<ul>` that holds it, so it is the `<ul>`'s unknowns that
  * decide whether the finding stands.
+ *
+ * `containerTags` is the other half. These rules have a second branch that
+ * reports the container itself — for bare text directly inside a list — and then
+ * the element in hand already *is* the container. `<ol><Link>Text</Link></ol>`
+ * lands there: the text came from a component, so the container's own unknowns
+ * are the ones that matter.
  */
-export const CONTAINER_MEMBER_RULES: Record<string, "parent" | "table"> = {
-  "adaptable/list-children": "parent",
-  "adaptable/definition-list": "parent",
-  "adaptable/td-has-header": "table",
+export const CONTAINER_MEMBER_RULES: Record<
+  string,
+  { ancestor: "parent" | "table"; containerTags: string[] }
+> = {
+  "adaptable/list-children": { ancestor: "parent", containerTags: ["ul", "ol"] },
+  "adaptable/definition-list": { ancestor: "parent", containerTags: ["dl"] },
+  "adaptable/td-has-header": { ancestor: "table", containerTags: ["table"] },
 };
 
 /** Rules that resolve an accessible name, which any descendant can supply. */

--- a/source/src/semantics.ts
+++ b/source/src/semantics.ts
@@ -1,0 +1,335 @@
+// The source-mode semantics: which rules can be asked of a component file at
+// all, and which of an element's unknowns make a rule's verdict unprovable.
+//
+// One principle governs every table here: what the source does not pin down
+// must produce silence, not a guess. A finding this package emits has to be a
+// defect at runtime no matter what the unknowns turn out to be; anything else
+// is a suppressed candidate for a later layer to adjudicate against real
+// evidence. False negatives are the accepted price.
+
+/**
+ * Never run in source mode.
+ *
+ * Two groups, for two different reasons:
+ *
+ * Rendering-dependent. Source has no layout, no stylesheet, and no paint, so
+ * these rules have nothing honest to read. Matches the disable list the ERB
+ * path already carries.
+ *
+ * Cross-element idref. The adapter emits both arms of a conditional as sibling
+ * elements, so a rule that reasons about one element by resolving an idref to
+ * another could be reasoning about a DOM that never exists. Modeling branch
+ * exclusivity is deliberately out of scope for v1.
+ */
+export const SOURCE_MODE_DISABLED_RULES = [
+  // Rendering-dependent
+  "distinguishable/color-contrast",
+  "distinguishable/color-contrast-enhanced",
+  "distinguishable/link-in-text-block",
+  "distinguishable/letter-spacing",
+  "distinguishable/line-height",
+  "distinguishable/word-spacing",
+  "keyboard-accessible/scrollable-region",
+  "keyboard-accessible/focus-visible",
+  "aria/aria-hidden-focus",
+  "landmarks/region",
+  // Cross-element idref
+  "labels-and-names/duplicate-id-aria",
+  "labels-and-names/form-label",
+  "adaptable/td-headers-attr",
+  "aria/aria-valid-attr-value",
+] as const;
+
+/**
+ * Rules whose subject is a fragment's missing *ancestor*. A component that
+ * renders one `<li>` keeps its list in the file that renders it; the engine is
+ * right that the parent is missing and wrong that it is a defect. Carried over
+ * from the ERB path, where these are the only two that produced false
+ * positives.
+ */
+export const FRAGMENT_DISABLED_RULES = [
+  "adaptable/listitem-parent",
+  "adaptable/aria-required-parent",
+  // Extended here, and only here: in source mode *every* file is a fragment by
+  // definition, and a `<dt>`/`<dd>` whose `<dl>` lives in the component that
+  // renders it has exactly the shape the two rules above were disabled for. The
+  // ERB path leaves this one on because it had produced no false positive
+  // there; a component file is a different bet.
+  "adaptable/dl-children",
+] as const;
+
+/**
+ * The one page-level rule a component file can still answer, and only when the
+ * file contains a literal intrinsic `<html>` tag (a Next.js root layout, a
+ * Remix root). All the evidence is local to that one tag, so it holds at the
+ * zero-false-positive bar. Deliberately not extended to document-title or
+ * landmark-main even then: Next supplies those from `metadata` and from
+ * children, so "missing" is unprovable.
+ */
+export const HTML_ELEMENT_RULE = "readable/html-has-lang";
+
+/**
+ * Rules whose verdict depends on what an element *contains* — container
+ * integrity, and every name-from-content rule. A component child or an opaque
+ * expression child makes the contents unknown, so these go silent for that
+ * element.
+ */
+export const CHILD_DEPENDENT_RULES = new Set([
+  "adaptable/list-children",
+  "adaptable/definition-list",
+  "adaptable/aria-required-children",
+  "adaptable/th-has-data-cells",
+  "adaptable/td-has-header",
+  "adaptable/empty-table-header",
+  "labels-and-names/frame-focusable-content",
+  "labels-and-names/multiple-labels",
+  "labels-and-names/label-content-mismatch",
+  "labels-and-names/label-title-only",
+  "labels-and-names/label-placeholder-only",
+  "aria/presentational-children-focusable",
+  "keyboard-accessible/nested-interactive",
+  "time-based-media/video-captions",
+  "time-based-media/audio-transcript",
+  "text-alternatives/object-alt",
+  "text-alternatives/svg-img-alt",
+  "text-alternatives/role-img-alt",
+  ...nameFromContentRules(),
+]);
+
+/**
+ * The child-dependent rules that report the offending *member* rather than the
+ * container, and where the container is. `list-children` reports the stray
+ * `<div>`, not the `<ul>` that holds it, so it is the `<ul>`'s unknowns that
+ * decide whether the finding stands.
+ */
+export const CONTAINER_MEMBER_RULES: Record<string, "parent" | "table"> = {
+  "adaptable/list-children": "parent",
+  "adaptable/definition-list": "parent",
+  "adaptable/td-has-header": "table",
+};
+
+/** Rules that resolve an accessible name, which any descendant can supply. */
+function nameFromContentRules(): string[] {
+  return [
+    "labels-and-names/button-name",
+    "labels-and-names/input-button-name",
+    "labels-and-names/summary-name",
+    "labels-and-names/aria-command-name",
+    "labels-and-names/aria-input-field-name",
+    "labels-and-names/aria-toggle-field-name",
+    "labels-and-names/aria-meter-name",
+    "labels-and-names/aria-progressbar-name",
+    "labels-and-names/aria-dialog-name",
+    "labels-and-names/aria-tooltip-name",
+    "labels-and-names/aria-treeitem-name",
+    "navigable/link-name",
+    "navigable/empty-heading",
+  ];
+}
+
+/**
+ * Rules that resolve an accessible name. `aria-labelledby` pointing at an id
+ * this file does not define is the normal way a component is named — the target
+ * lives in the page that renders it — so a missing-name finding on such an
+ * element is unprovable here.
+ */
+export const NAME_FAMILY_RULES = new Set(nameFromContentRules());
+
+/**
+ * Rules that read the document as an ordered whole. Emitting both arms of a
+ * conditional puts elements next to each other that never coexist, so these go
+ * silent for the whole file once it contains any exclusive branch.
+ */
+export const DOC_ORDER_DEPENDENT_RULES = new Set([
+  "navigable/heading-order",
+  "navigable/p-as-heading",
+  "labels-and-names/frame-title-unique",
+  "labels-and-names/multiple-labels",
+]);
+
+/**
+ * Attributes that can take an element — and everything under it — out of the
+ * accessibility tree. An expression value for one of these silences every
+ * finding in the subtree, because the elements may not be there to violate
+ * anything. `role` is not here: it changes what an element *is*, which the
+ * per-rule dependency table below already accounts for.
+ */
+export const SUBTREE_SEMANTICS_ATTRIBUTES = new Set(["aria-hidden", "hidden", "inert", "style"]);
+
+/**
+ * Style properties that can remove an element from the accessibility tree. A
+ * style object with an expression value for one of these is a semantics
+ * unknown; an expression value for `width` is not.
+ */
+export const VISIBILITY_STYLE_PROPERTIES = new Set([
+  "display",
+  "visibility",
+  "opacity",
+  "content-visibility",
+]);
+
+/**
+ * Per rule, the attributes whose *values* it reads. An expression value for one
+ * of them makes that rule unprovable on that element; an expression value for
+ * anything else leaves the rule free to fire.
+ *
+ * This is the table that buys the yield. `<img src={user.avatarUrl} />` with no
+ * alt is the case the whole package exists for: `src` is not in img-alt's
+ * dependencies, `alt` is provably absent, so the finding stands.
+ *
+ * A rule absent from this table depends on `"any"`: any expression-valued
+ * attribute on the element silences it. That is the safe default, and the way
+ * to give a rule more reach is to read it and add a row.
+ */
+export const RULE_ATTRIBUTE_DEPENDENCIES: Record<string, readonly string[]> = {
+  // Reads alt, role, tabindex (presentation is overridden when focusable), and
+  // the accessible name (aria-label / aria-labelledby / title).
+  "text-alternatives/img-alt": [
+    "alt",
+    "role",
+    "tabindex",
+    "aria-label",
+    "aria-labelledby",
+    "title",
+  ],
+  "text-alternatives/input-image-alt": [
+    "alt",
+    "type",
+    "role",
+    "value",
+    "aria-label",
+    "aria-labelledby",
+    "title",
+  ],
+  "text-alternatives/area-alt": ["alt", "href", "role", "aria-label", "aria-labelledby", "title"],
+  // Name-family rules: name sources only.
+  "navigable/link-name": ["href", "role", "aria-label", "aria-labelledby", "title"],
+  "labels-and-names/button-name": [
+    "type",
+    "value",
+    "role",
+    "disabled",
+    "tabindex",
+    "aria-label",
+    "aria-labelledby",
+    "title",
+  ],
+  "labels-and-names/input-button-name": [
+    "type",
+    "value",
+    "role",
+    "aria-label",
+    "aria-labelledby",
+    "title",
+  ],
+  "labels-and-names/summary-name": ["role", "aria-label", "aria-labelledby", "title"],
+  "navigable/empty-heading": ["role", "aria-label", "aria-labelledby", "title"],
+  // Container integrity: the container's own role is the only value read (a
+  // presentational container has no semantics to enforce). What matters for
+  // these is the child set, which CHILD_DEPENDENT_RULES covers.
+  "adaptable/list-children": ["role"],
+  "adaptable/dl-children": ["role"],
+  "adaptable/definition-list": ["role"],
+  "adaptable/aria-required-children": ["role"],
+  // Single-attribute rules.
+  "keyboard-accessible/tabindex": ["tabindex"],
+  "keyboard-accessible/accesskeys": ["accesskey"],
+  "adaptable/autocomplete-valid": ["autocomplete", "type", "role"],
+  "adaptable/scope-attr-valid": ["scope", "role"],
+  "readable/valid-lang": ["lang", "xml:lang"],
+  [HTML_ELEMENT_RULE]: ["lang"],
+  // Judges which aria attributes are *present*, never their values, so an
+  // expression value cannot change the verdict.
+  "aria/aria-valid-attr": [],
+  "aria/aria-roles": ["role"],
+  "aria/aria-required-attr": ["role"],
+  "aria/aria-allowed-attr": ["role"],
+  "aria/aria-prohibited-attr": ["role", "aria-label", "aria-labelledby"],
+};
+
+/** Every rule not in the table above depends on every unknown attribute. */
+export const DEPENDS_ON_ANY_UNKNOWN = "any";
+
+export function attributeDependencies(
+  ruleId: string,
+): readonly string[] | typeof DEPENDS_ON_ANY_UNKNOWN {
+  return RULE_ATTRIBUTE_DEPENDENCIES[ruleId] ?? DEPENDS_ON_ANY_UNKNOWN;
+}
+
+/**
+ * Stand-in for an expression in text position. Any word works; it only has to
+ * be non-empty and read as plain text. Same choice, and the same reasoning, as
+ * the ERB neutralizer: a missing name is reported, a stray text node is not.
+ */
+export const TEXT_PLACEHOLDER = "Text";
+
+/** Stand-in for an expression in attribute position: present, non-empty, inert. */
+export const ATTRIBUTE_PLACEHOLDER = "unknown";
+
+/**
+ * Elements read for their text content: their accessible name comes from what
+ * is inside them, so an expression there is text the user will hear. Note what
+ * is absent — `ul`, `ol`, `dl`, `table`, `tr`, `select` and the layout
+ * containers constrain their *children*, and text dropped into one is a
+ * violation of the container, not a name for it. Copied from the ERB
+ * neutralizer, which is where this trade was settled.
+ */
+export const TEXT_ELEMENTS = new Set([
+  "a",
+  "abbr",
+  "address",
+  "b",
+  "button",
+  "caption",
+  "cite",
+  "code",
+  "dd",
+  "dt",
+  "em",
+  "figcaption",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "i",
+  "label",
+  "legend",
+  "li",
+  "mark",
+  "option",
+  "output",
+  "p",
+  "q",
+  "s",
+  "small",
+  "span",
+  "strong",
+  "sub",
+  "summary",
+  "sup",
+  "td",
+  "th",
+  "time",
+  "title",
+  "u",
+]);
+
+/** No content, so they never become a parent and never self-close wrongly. */
+export const VOID_ELEMENTS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);

--- a/source/src/test-dom.ts
+++ b/source/src/test-dom.ts
@@ -1,0 +1,24 @@
+import { Window } from "happy-dom";
+
+let shared: Document | null = null;
+
+/**
+ * One document, plus the globals `@accesslint/core`'s rules read — the same
+ * setup the PR reviewer's bin script performs, for the same reason: the engine
+ * talks to a DOM API, not to a string.
+ *
+ * Deliberately a singleton. Rules use `instanceof HTMLImageElement` and friends,
+ * and a second happy-dom Window brings its own constructors that elements from
+ * the first one fail against.
+ */
+export function testDocument(): Document {
+  if (shared) return shared;
+  const window = new Window();
+  const globals = globalThis as unknown as Record<string, unknown>;
+  for (const key of Object.getOwnPropertyNames(window)) {
+    if (!globals[key]) globals[key] = (window as unknown as Record<string, unknown>)[key];
+  }
+  globals.getComputedStyle = window.getComputedStyle.bind(window);
+  shared = window.document as unknown as Document;
+  return shared;
+}

--- a/source/src/types.ts
+++ b/source/src/types.ts
@@ -21,6 +21,8 @@ export type UnknownKind =
   | "unknown-semantics"
   /** aria-labelledby points at an id this file does not define. */
   | "external-idref"
+  /** The container the rule reasons about is not in this file. */
+  | "external-container"
   /** The file emits exclusive branches, so document order is not a real order. */
   | "exclusive-branches";
 
@@ -66,6 +68,12 @@ export interface SourceAuditResult {
   dialect: Dialect | null;
   /** False when the file could not be parsed — findings and candidates are empty. */
   parsed: boolean;
+  /**
+   * Set when the file was deliberately not audited: its JSX is rendered by
+   * something that is not a DOM, or it is a test file. Findings and candidates
+   * are empty.
+   */
+  skipped?: "non-dom-renderer" | "test-file";
   /** The synthetic HTML the engine audited, markers removed. For debugging. */
   html: string;
 }
@@ -84,6 +92,11 @@ export interface AuditSourceOptions {
   filename?: string;
   /** Overrides detection from `filename`. */
   dialect?: Dialect;
+  /**
+   * Audit `*.test.tsx`, `__tests__/`, and fixture directories too. Off by
+   * default: a fixture's markup is written to be wrong.
+   */
+  includeTestFiles?: boolean;
   /**
    * Merged over the source-mode defaults. `disabledRules` adds to
    * `SOURCE_MODE_DISABLED_RULES` rather than replacing it, and `componentMode`

--- a/source/src/types.ts
+++ b/source/src/types.ts
@@ -1,0 +1,93 @@
+import type { AuditOptions, Violation } from "@accesslint/core";
+
+/** Source dialects this package can audit. Only `jsx`/`tsx` ship today. */
+export type Dialect = "jsx" | "tsx";
+
+/**
+ * Why the static layer could not decide a finding. Every suppressed candidate
+ * carries one, and it names the evidence a resolver (cross-file import walk, or
+ * the LLM verifier) would have to produce to unsuppress the finding.
+ */
+export type UnknownKind =
+  /** The element carries `{...spread}`, so an attribute's absence is unprovable. */
+  | "spread"
+  /** A child is a component element, so what it renders is unknown here. */
+  | "component-child"
+  /** A child is an expression whose shape does not resolve to JSX or a literal. */
+  | "opaque-expression"
+  /** An attribute the rule reads has an expression value. */
+  | "unknown-attribute-value"
+  /** role / aria-hidden / hidden / inert / style is unknown on the element or an ancestor. */
+  | "unknown-semantics"
+  /** aria-labelledby points at an id this file does not define. */
+  | "external-idref"
+  /** The file emits exclusive branches, so document order is not a real order. */
+  | "exclusive-branches";
+
+export interface SourceUnknown {
+  kind: UnknownKind;
+  /** Human-readable statement of what is unknown, for the comment or the log. */
+  detail: string;
+  /** The attribute involved, when the unknown is attribute-shaped. */
+  attribute?: string;
+  /** The source text of the expression involved, truncated. */
+  expression?: string;
+}
+
+/** A violation the static layer proved, located in the source file. */
+export interface SourceFinding {
+  ruleId: string;
+  impact: Violation["impact"];
+  message: string;
+  context?: string;
+  /** The synthetic HTML for the element, as the engine saw it. */
+  html: string;
+  selector: string;
+  /** 1-based line in the *source* file, from the AST. */
+  line: number;
+  /** 1-based column in the source file. */
+  column: number;
+  /** The filename passed in, when one was. */
+  file?: string;
+}
+
+/**
+ * A violation the engine reported that the source cannot prove. Never a comment
+ * on its own: it is the input to the unsuppression layer, which may promote it
+ * only against real repo evidence.
+ */
+export interface SourceCandidate extends SourceFinding {
+  unknown: SourceUnknown;
+}
+
+export interface SourceAuditResult {
+  findings: SourceFinding[];
+  candidates: SourceCandidate[];
+  dialect: Dialect | null;
+  /** False when the file could not be parsed — findings and candidates are empty. */
+  parsed: boolean;
+  /** The synthetic HTML the engine audited, markers removed. For debugging. */
+  html: string;
+}
+
+export interface AuditSourceOptions {
+  /** The file's source text. */
+  source: string;
+  /**
+   * A document to audit in. Emptied and rewritten. The caller owns the DOM
+   * implementation (happy-dom, jsdom, a browser) exactly as `@accesslint/core`
+   * expects, including the globals its rules read (`getComputedStyle`, element
+   * constructors).
+   */
+  document: Document;
+  /** Used for dialect detection and reported on every finding. */
+  filename?: string;
+  /** Overrides detection from `filename`. */
+  dialect?: Dialect;
+  /**
+   * Merged over the source-mode defaults. `disabledRules` adds to
+   * `SOURCE_MODE_DISABLED_RULES` rather than replacing it, and `componentMode`
+   * cannot be turned off — see decision 8 in the plan.
+   */
+  auditOptions?: Omit<AuditOptions, "componentMode">;
+}

--- a/source/tsconfig.json
+++ b/source/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/source/tsdown.config.ts
+++ b/source/tsdown.config.ts
@@ -7,4 +7,6 @@ export default defineConfig({
   fixedExtension: false,
   dts: true,
   treeshake: true,
+  publint: true,
+  attw: true,
 });

--- a/source/tsdown.config.ts
+++ b/source/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["./src/index.ts", "./src/jsx/index.ts"],
+  format: ["esm", "cjs"],
+  platform: "neutral",
+  fixedExtension: false,
+  dts: true,
+  treeshake: true,
+});


### PR DESCRIPTION
A new package, `@accesslint/source`: parse a component file, render its intrinsic elements as HTML, run [`@accesslint/core`](../core) over the result, and report findings against the line in the file you wrote. No bundler, no dev server, no rendering, and no execution of the code being audited.

## Why

Auditing a component file by handing it to an HTML parser is not a thinner audit than auditing markup. It is a wrong one, in both directions:

- `<img src={user.avatarUrl} />` with no alt produces **nothing**. The rule fires, but the serializer writes `src="{user.avatarUrl}"`, and matching that back against the unquoted source to find a line fails, so the violation is discarded.
- `{items.map(...)}` inside a `<ul>` reads as direct text content and fires `adaptable/list-children`, a finding that is never true.

Mostly silence, punctuated by brace-induced false positives.

## The contract

**What the source does not pin down produces silence, not a guess.** A finding is a defect at runtime whatever the unknowns turn out to be. Everything else comes back as a *candidate*, carrying the unknown that stopped it, for a later layer that can go get the missing evidence.

That split is the point: findings are safe to post as review comments on a protected branch, where every comment blocks a merge until a human clears it. False negatives are the accepted price.

| The source says | The audit reads it as |
| --- | --- |
| `<img src={url} />` | `src` present with an unknown value; a missing `alt` here is still a finding |
| `<img {...props} />` | absence unprovable, so the finding becomes a candidate |
| `<img {...props} alt="" />` | `alt` provably empty: nothing after a spread can override it |
| `<Button>…</Button>` | the component vanishes, its children are audited in place |
| `<ul><MenuItem /></ul>` | contents unknown, so container rules go quiet |
| `<ul>{items.map((i) => <div />)}</ul>` | the `<div>` is real, and reported |
| `{cond ? <a /> : <b />}` | both arms, so document-order rules go quiet |
| a file that does not parse | no findings at all |

## Precision

Every finding was hand-triaged against ten popular React repositories — shadcn/ui, supabase, material-ui, chakra, primer/react, docusaurus, excalidraw, react.dev, headlessui, vercel/commerce.

**12,557 files, 15 seconds, 109 findings, zero confirmed false positives.**

The first run produced 186. Triage found six false-positive classes in the semantics and two structural defects, each now a named test in `src/audit.test.ts` under "what the corpus taught":

1. An accessible name comes from the whole subtree, so an unknown one level down silences the name rules while container integrity still reads only direct children.
2. A list reporting its own bare text *is* the container: `<ol><Link>text</Link></ol>` renders an `<a>` child at runtime.
3. JSX rendered by satori is not a DOM. Half the first run's `img-alt` findings were OG-image generators.
4. Test files and fixtures are written to be wrong: all seven positive-`tabIndex` findings were focus-trap fixtures.
5. `keyboard-accessible/focus-order` cannot tell a keyboard-reachable scroll container from a control built out of a div without layout.
6. A `hidden` class hides only when no breakpoint shows it again. Treating `hidden lg:block` as hidden silently lost 16 real findings.
7. **One document per root.** A component returning `<tr>` puts the parser in table mode, and everything after it is foster-parented out of its own parent, element and text separately. A docusaurus page audited that way reported an empty `<h1>`, an empty `<button>` and a nameless link, none of them true.
8. **Identity from the location marker, not the CSS selector.** Two `<a href={expr}>` both render `href="unknown"`, so both got the same selector and three findings landed on one line.

The sweep harness and full triage log are kept out of version control.

## One core change

`labels-and-names/label-content-mismatch` reported `<a aria-label="Deploy on Vercel"><span>▲</span><span>Deploy</span></a>`. Adjacent spans contribute no whitespace, so the visible text arrives as `▲Deploy` and the word-overlap check, which required two significant words, never ran. It now strips decorative characters from both ends of each word and accepts a single significant word. This is a core rule and the same false positive occurs in plain HTML, which is why the fix belongs there rather than in the adapter.

## Verification

All 39 turbo `build`, `typecheck` and `test` tasks pass, including core's 974 unit tests. 127 tests in the new package: the plan's worked cases, the corpus regressions, and the zero-false-positive invariants stated as properties over 13 component shapes crossed with the three mutations that introduce unknowns.

`bun run ci` is red on `main` independently of this branch: `format:check` fails on 20 files this PR does not touch, and eslint errors in `report/*.js`. Verified by stashing. Everything under `source/` is prettier- and eslint-clean.

## Scope

JSX and TSX. Vue and Svelte map onto the same semantics and are next, each behind the same corpus gate. Nothing is published yet.

