### PR TITLE
fix(ci): install playwright browsers from bench workspace

### DIFF
--- a/.github/workflows/web-bench.yml
+++ b/.github/workflows/web-bench.yml
@@ -59,7 +59,9 @@ jobs:
       - name: Build @accesslint/core (needed for IIFE injection)
         run: npx turbo run build --filter=@accesslint/core
 
-      - run: bunx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        working-directory: bench
+        run: bunx playwright install --with-deps chromium
 
       - name: Run web benchmark (shard ${{ matrix.shard }}/20)
         working-directory: bench


### PR DESCRIPTION
## Summary
- The Web Benchmark workflow has failed repeatedly (July 27, July 20 x2, June 2, April 26 x2) with `browserType.launch: Executable doesn't exist at .../chromium_headless_shell-1217/...`
- Root cause: the Playwright browser install step ran `bunx playwright install --with-deps chromium` from the repo root, where there's no npm `playwright` devDependency (root package.json's `"playwright"` workspace entry is the local `@accesslint/playwright` package). `bunx` fell back to an unpinned, latest playwright from the registry, downloading browsers for a different revision than the one `bench/`'s pinned `playwright@^1.58.1` expects at launch time.
- Fix: run the install step with `working-directory: bench` so `bunx` resolves the workspace's pinned playwright binary, keeping the installed browser revision in sync with what the benchmark script actually launches.

## Test plan
- [ ] Trigger the Web Benchmark workflow via `workflow_dispatch` (or wait for the next `@accesslint/core` publish) and confirm all 20 shards complete and the aggregate job produces a summary