### PR TITLE
ci: add publish workflow for @accesslint/source

### DIFF
--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -1,0 +1,39 @@
+name: Publish @accesslint/source
+
+on:
+  push:
+    tags: ["source/v*"]
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - run: bun install
+
+      - run: npx turbo run test --filter=@accesslint/source
+
+      - run: npx turbo run build --filter=@accesslint/source
+
+      - run: npm publish --provenance --access public
+        working-directory: source
+
+      - name: Create GitHub release
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --title "@accesslint/source v${GITHUB_REF_NAME#source/v}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Tag-triggered publish for the new package, matching the other publish workflows: push a `source/v*` tag, CI runs the package's tests and build through turbo, publishes to npm with provenance, and creates a GitHub release.

Note: the first publish of v0.1.0 still needs to happen manually since the CI token cannot create new packages; this workflow covers releases after that.