### PR TITLE
fix(source): publish a manifest npm can install

### DIFF
--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -30,6 +30,28 @@ jobs:
 
       - run: npx turbo run build --filter=@accesslint/source
 
+      # `npm publish` ships the manifest as written, and bun's `workspace:*` is
+      # not a range npm can resolve — a consumer running `npm install` gets
+      # EUNSUPPORTEDPROTOCOL and cannot install the package at all. Same step,
+      # and same reason, as publish-playwright.yml and publish-mcp.yml.
+      - name: Replace workspace:* with published versions
+        working-directory: source
+        run: |
+          node -e "
+          const fs = require('fs'), path = require('path');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          for (const sec of ['dependencies', 'devDependencies', 'peerDependencies']) {
+            for (const [name, ver] of Object.entries(pkg[sec] ?? {})) {
+              if (ver === 'workspace:*') {
+                const dir = name.split('/')[1];
+                const dep = JSON.parse(fs.readFileSync(path.join('..', dir, 'package.json'), 'utf8'));
+                pkg[sec][name] = dep.version;
+              }
+            }
+          }
+          fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
       - run: npm publish --provenance --access public
         working-directory: source
 

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accesslint/source",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Audit component source (JSX/TSX) for accessibility from a real parse — synthetic HTML into @accesslint/core, with source lines and no guesses.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
`@accesslint/source@0.1.0` is on the registry and cannot be installed by anyone:

```
$ npm install --save-exact @accesslint/source@0.1.0
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

The published manifest declares the dependency as the placeholder:

```
$ npm view @accesslint/source dependencies
{ '@accesslint/core': 'workspace:*', '@babel/parser': '^7.26.0' }
```

## Why it happened

`npm publish` ships `package.json` as written, and `workspace:*` is bun's protocol, not a range npm can resolve. Every other package here that depends on a sibling already handles this: `publish-playwright.yml` and `publish-mcp.yml` carry a **"Replace workspace:\* with published versions"** step immediately before publishing, which is why their manifests read `0.16.0` and `^0.13.0` on the registry.

`publish-source.yml` was modeled on `publish-heal-diff.yml`, which has no workspace dependencies and therefore never needed the step. Nothing caught it: the package builds, tests, `publint` and `attw` all pass, because the manifest is only wrong from a *consumer's* resolver's point of view.

## The fix

The same step, verbatim, and a bump to `0.1.1` — npm will not let a version be republished. Running the step by hand against this branch produces what should have shipped:

```
rewritten deps: {"@accesslint/core":"0.17.0","@babel/parser":"^7.26.0"}
```

## After merging

```
git tag source/v0.1.1 && git push origin source/v0.1.1
```

Worth deprecating the broken version so nobody pins it:

```
npm deprecate @accesslint/source@0.1.0 "Unpublishable manifest (workspace:* dependency); use 0.1.1 or later"
```

The consumer waiting on this is [accesslint.com#189](https://github.com/AccessLint/accesslint.com/pull/189), which cannot add the dependency until a resolvable version exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)