### PR TITLE
fix(core): don't flag hidden focusable descendants of presentational roles

### DIFF
--- a/core/src/rules/aria/presentational-children-focusable.test.ts
+++ b/core/src/rules/aria/presentational-children-focusable.test.ts
@@ -68,4 +68,65 @@ describe(RULE_ID, () => {
       '<div role="img"><input type="text" tabindex="-1"></div>',
     );
   });
+
+  it("skips a link hidden by inline display:none inside role=button", () => {
+    expectNoViolations(
+      presentationalChildrenFocusable,
+      '<div role="button"><div style="display:none"><a href="/x">Link</a></div></div>',
+    );
+  });
+
+  it("skips a link hidden by a stylesheet class inside role=button", () => {
+    // A common card-with-collapsed-popup shape: the popup's links are
+    // unreachable until it opens, and hiding comes from a class rather than an
+    // inline style, so an inline-only check would report all of them.
+    expectNoViolations(
+      presentationalChildrenFocusable,
+      `<html><head><style>.popup_content { display: none; }</style></head>
+       <body>
+         <div role="button">
+           <img src="/thumbnail.jpg" alt="">
+           <div class="popup_content">
+             <a href="https://example.com/one">One</a>
+             <a href="https://example.com/two">Two</a>
+           </div>
+         </div>
+       </body></html>`,
+    );
+  });
+
+  it("skips a link hidden by visibility:hidden inside role=button", () => {
+    expectNoViolations(
+      presentationalChildrenFocusable,
+      `<html><head><style>.panel { visibility: hidden; }</style></head>
+       <body><div role="button"><div class="panel"><a href="/x">Link</a></div></div></body></html>`,
+    );
+  });
+
+  it("still reports a visible sibling when another descendant is hidden", () => {
+    expectViolations(
+      presentationalChildrenFocusable,
+      `<html><head><style>.popup_content { display: none; }</style></head>
+       <body>
+         <div role="button">
+           <div class="popup_content"><a href="/hidden">Hidden</a></div>
+           <a href="/visible">Visible</a>
+         </div>
+       </body></html>`,
+      { count: 1, ruleId: RULE_ID, selectorIncludes: "a" },
+    );
+  });
+
+  it("still reports a visually hidden but focusable link inside role=button", () => {
+    // sr-only content is off-screen, not out of the tab order — a keyboard user
+    // can still land on it, so it remains a violation.
+    expectViolations(
+      presentationalChildrenFocusable,
+      `<html><head><style>
+         .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; }
+       </style></head>
+       <body><div role="button"><a href="/x" class="sr-only">Skip</a></div></body></html>`,
+      { count: 1, ruleId: RULE_ID },
+    );
+  });
 });

--- a/core/src/rules/aria/presentational-children-focusable.ts
+++ b/core/src/rules/aria/presentational-children-focusable.ts
@@ -1,6 +1,6 @@
 import type { Rule } from "../types";
 import { getSelector, getHtmlSnippet } from "../utils/selector";
-import { isAriaHidden, getComputedRole, FOCUSABLE_SELECTOR } from "../utils/aria";
+import { isAriaHidden, isComputedHidden, getComputedRole, FOCUSABLE_SELECTOR } from "../utils/aria";
 
 /**
  * Roles with the "children presentational" trait per ARIA 1.2.
@@ -57,6 +57,11 @@ export const presentationalChildrenFocusable: Rule = {
         // Skip elements with tabindex="-1" — they are not keyboard-focusable
         // (they can receive programmatic focus, but are not reachable via Tab)
         if (child.getAttribute("tabindex") === "-1") continue;
+        // Skip hidden descendants — display:none / visibility:hidden elements are
+        // never in the tab order, so they cannot strand a keyboard user. The check
+        // must be computed, not inline: collapsed popups and disclosure panels are
+        // typically hidden by a stylesheet class.
+        if (isComputedHidden(child)) continue;
 
         violations.push({
           ruleId: "aria/presentational-children-focusable",


### PR DESCRIPTION
## The bug

`aria/presentational-children-focusable` (ACT [307n5z](https://www.w3.org/WAI/standards-guidelines/act/rules/307n5z/)) flagged focusable descendants of children-presentational roles without checking whether the descendant was actually reachable. It tested only `!disabled && tabindex !== "-1"`.

On a real page this produced **17 false positives** in a single common shape: cards marked `div[role=button]` wrapping a collapsed popup that the theme hides with a stylesheet class. The links inside that popup are unfocusable at audit time, and when the popup opens the theme moves the content out of the card entirely, so it is never both focusable and inside the button role. The rule asks whether a keyboard user can reach content a screen reader user cannot perceive — nobody can tab to a `display:none` element, so per 307n5z these pass.

## The fix

One guard in the descendant loop:

```ts
if (isComputedHidden(child)) continue;
```

- **`isComputedHidden`, not a new helper.** It's the idiom `button-name`, `form-label`, `autocomplete-valid` and five other rules already use, and it walks the ancestor chain for `aria-hidden`, the `hidden` attribute, and computed `display:none` / `visibility:hidden`. That ancestor walk is what makes it right here: the links carry no hiding style, their wrapper does.
- **Computed, not inline.** Collapsed popups and disclosure panels are hidden by class, not by a `style` attribute.
- **Deliberately not `isHidden` from `utils/visibility`.** That one also treats sr-only patterns (`clip: rect(0 0 0 0)`, 1px-with-`overflow:hidden`) as hidden. But sr-only content is off-screen, *not* out of the tab order — a keyboard user can still land on it, so it must keep reporting. There's a test pinning that distinction.
- The container check at the top of the loop is untouched; `isComputedHidden` on the descendant already subsumes a hidden container.

## Tests

Five new cases, three for the fix and two guarding against over-suppression:

- inline `display:none` inside `role=button`
- a stylesheet class, matching the card-with-collapsed-popup shape above
- `visibility:hidden`
- a visible sibling still reports when a hidden link is also present
- an sr-only focusable link still reports

## Verification

Built the IIFE from this branch and ran the rule against the reported page in headless Chromium, with the published bundle from a consuming app as a control. The first run hit a `networkidle` timeout, so both were re-run under an identical `load` + 3s settle:

| bundle | violations |
| --- | --- |
| published (control) | 17 |
| this branch | 0 |

Every one of the control's 17 was inside a collapsed popup.

Also green: all 13 tests in the file, the full 982-test unit suite, and `tsc --noEmit`.

## Rollout

Reaching the runner needs a `@accesslint/core` release plus a dependency bump downstream — nothing in this PR changes deployed behavior on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)