### PR TITLE
fix(core): evaluate the gradient, not the color it paints over

### DIFF
--- a/core/src/integration/color-contrast.browser.test.ts
+++ b/core/src/integration/color-contrast.browser.test.ts
@@ -284,3 +284,157 @@ describe("visual edge cases", () => {
     expectNoViolations(run());
   });
 });
+
+describe("gradient backgrounds", () => {
+  it("passes: white hero text over a dark gradient painted on a white background-color", () => {
+    // Regression for #21: the gradient paints over background-color, so the
+    // white fallback color is not what shows behind the text.
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero {
+          background-color: #fff;
+          background-image: linear-gradient(rgb(19, 19, 39), rgb(40, 40, 80));
+          padding: 40px;
+        }
+        .hero h1 { color: #fff }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("passes: white text over a dark gradient with a white body behind it", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero { background-image: linear-gradient(rgb(19, 19, 39), rgb(40, 40, 80)); padding: 40px }
+        .hero h1 { color: #fff }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("passes: white text over an angled multi-stop dark gradient", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero {
+          background-color: #fff;
+          background-image: linear-gradient(
+            135deg,
+            rgb(19, 19, 39) 0%,
+            rgb(30, 30, 60) 50%,
+            rgb(10, 10, 20) 100%
+          );
+          padding: 40px;
+        }
+        .hero h1 { color: #fff }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("passes: white text nested below a wrapper inside the gradient element", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero {
+          background-color: #fff;
+          background-image: linear-gradient(rgb(19, 19, 39), rgb(40, 40, 80));
+          padding: 40px;
+        }
+        h1 { color: #fff }
+      </style>
+      <div class="hero"><div class="inner"><h1>Ship accessible software</h1></div></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("passes: white text under a translucent white scrim over a dark gradient", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero { background-image: linear-gradient(rgb(19, 19, 39), rgb(40, 40, 80)); padding: 40px }
+        h1 { color: #fff; background-color: rgba(255, 255, 255, 0.08) }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("fails: dark text over a dark gradient, even at the best-contrast stop", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero {
+          background-color: #fff;
+          background-image: linear-gradient(rgb(19, 19, 39), rgb(40, 40, 80));
+          padding: 40px;
+        }
+        .hero h1 { color: #333 }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    const violations = run();
+    expectViolation(violations, "h1");
+    expect(violations[0].context).toMatch(/background: gradient/);
+  });
+
+  it("fails: white text over a light gradient painted on a black background-color", () => {
+    setContent(`
+      <style>
+        .hero {
+          background-color: #000;
+          background-image: linear-gradient(rgb(240, 240, 240), rgb(255, 255, 255));
+          padding: 40px;
+        }
+        .hero h1 { color: #fff }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    expectViolation(run(), "h1");
+  });
+
+  it("passes: fully transparent gradient stops fall back to the color behind the gradient", () => {
+    setContent(`
+      <style>
+        body { background: #101020 }
+        .hero { background-image: linear-gradient(transparent, transparent); padding: 40px }
+        .hero h1 { color: #fff }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("fails: a translucent dark gradient over white stays too light for white text", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero {
+          background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.15));
+          padding: 40px;
+        }
+        .hero h1 { color: #fff }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    expectViolation(run(), "h1");
+  });
+
+  it("skips: gradient behind a non-gradient background image is not second-guessed", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero { background-image: linear-gradient(rgb(19, 19, 39), rgb(40, 40, 80)); padding: 40px }
+        .photo { background-image: url(data:image/gif;base64,R0lGODlhAQABAAAAACw=); padding: 20px }
+        h1 { color: #fff }
+      </style>
+      <div class="hero"><div class="photo"><h1>Ship accessible software</h1></div></div>
+    `);
+    expectNoViolations(run());
+  });
+});

--- a/core/src/rules/distinguishable/color-contrast-helpers.ts
+++ b/core/src/rules/distinguishable/color-contrast-helpers.ts
@@ -28,29 +28,77 @@ import {
 } from "../utils/visibility";
 import { hasUnreliableVisualEffects } from "../utils/filters";
 
-/** Find the nearest ancestor (or self) with a CSS gradient background. */
-function findAncestorGradient(el: Element): { bgImage: string; gradientEl: Element } | null {
+interface BackgroundLayer {
+  color: [number, number, number];
+  alpha: number;
+}
+
+interface GradientBackground {
+  bgImage: string;
+  /** Opaque color painted behind the gradient, for translucent stops. */
+  behind: [number, number, number];
+  /** Translucent layers painted over the gradient, innermost first. */
+  overlays: BackgroundLayer[];
+}
+
+/** Resolve the opaque color painted behind a gradient element. */
+function colorBehindGradient(gradientEl: Element): [number, number, number] {
+  const parent = gradientEl.parentElement;
+  const base = (parent && getEffectiveBackgroundColor(parent)) || [255, 255, 255];
+  const bg = getCachedComputedStyle(gradientEl).backgroundColor;
+  const own = parseColor(bg);
+  if (!own) return base;
+  const alpha = parseColorAlpha(bg);
+  if (alpha <= 0) return base;
+  return alpha >= 1 ? own : compositeColors(own, base, alpha);
+}
+
+/**
+ * Find the nearest ancestor (or self) with a CSS gradient background, along
+ * with any translucent background layers between it and the text.
+ */
+function findAncestorGradient(el: Element): GradientBackground | null {
+  const overlays: BackgroundLayer[] = [];
   let current: Element | null = el;
   while (current) {
     const style = getCachedComputedStyle(current);
     const bgImg = style.backgroundImage;
     if (bgImg && bgImg !== "none" && bgImg !== "initial") {
-      return bgImg.includes("gradient(") ? { bgImage: bgImg, gradientEl: current } : null;
+      if (!bgImg.includes("gradient(")) return null;
+      return { bgImage: bgImg, behind: colorBehindGradient(current), overlays };
     }
     const bg = style.backgroundColor;
     if (!bg || bg === "transparent" || bg === "rgba(0, 0, 0, 0)" || bg === "rgba(0 0 0 / 0)") {
       current = current.parentElement;
       continue;
     }
+    const alpha = parseColorAlpha(bg);
     // Nearly transparent — keep looking
-    if (parseColorAlpha(bg) < 0.01) {
+    if (alpha < 0.01) {
       current = current.parentElement;
       continue;
     }
-    // Solid background found — no gradient shows through
-    return null;
+    const color = parseColor(bg);
+    if (!color) return null;
+    // Opaque background found — no gradient shows through
+    if (alpha >= 1) return null;
+    // Translucent layer — the gradient still shows through it
+    overlays.push({ color, alpha });
+    current = current.parentElement;
   }
   return null;
+}
+
+/** Paint the translucent layers (innermost first) over a gradient stop. */
+function applyOverlays(
+  stop: [number, number, number],
+  overlays: BackgroundLayer[],
+): [number, number, number] {
+  let result = stop;
+  for (let i = overlays.length - 1; i >= 0; i--) {
+    result = compositeColors(overlays[i].color, result, overlays[i].alpha);
+  }
+  return result;
 }
 
 /** Check gradient background contrast and return a violation if insufficient. */
@@ -62,10 +110,11 @@ function checkGradientContrast(
   threshold: number,
   ruleId: string,
   level: "AA" | "AAA",
-  gradientBg: string,
-  transparentFallback: [number, number, number],
+  gradient: GradientBackground,
 ) {
-  const stops = parseGradientStops(gradientBg, transparentFallback);
+  const stops = parseGradientStops(gradient.bgImage, gradient.behind).map((stop) =>
+    applyOverlays(stop, gradient.overlays),
+  );
   if (stops.length === 0) return null;
 
   // Use the gradient stop that gives the BEST contrast with fg.
@@ -179,7 +228,7 @@ export function checkContrast(doc: Document, ruleId: string, level: "AA" | "AAA"
 
     const threshold = level === "AAA" ? (isLargeText(el) ? 4.5 : 7) : isLargeText(el) ? 3 : 4.5;
 
-    let bg = getEffectiveBackgroundColor(el);
+    const bg = getEffectiveBackgroundColor(el);
 
     // If no solid background found, check ancestor chain for gradient backgrounds
     if (!bg) {
@@ -187,9 +236,6 @@ export function checkContrast(doc: Document, ruleId: string, level: "AA" | "AAA"
       if (parsedShadows) continue;
       const gradientInfo = findAncestorGradient(el);
       if (gradientInfo) {
-        const parentBg = gradientInfo.gradientEl.parentElement
-          ? getEffectiveBackgroundColor(gradientInfo.gradientEl.parentElement)
-          : null;
         const violation = checkGradientContrast(
           el,
           fg,
@@ -198,8 +244,7 @@ export function checkContrast(doc: Document, ruleId: string, level: "AA" | "AAA"
           threshold,
           ruleId,
           level,
-          gradientInfo.bgImage,
-          parentBg ?? [255, 255, 255],
+          gradientInfo,
         );
         if (violation) violations.push(violation);
       }

--- a/core/src/rules/utils/color.ts
+++ b/core/src/rules/utils/color.ts
@@ -170,6 +170,10 @@ function _computeEffectiveBg(el: Element): [number, number, number] | null {
     const style = getCachedComputedStyle(current);
     const bgImg = style.backgroundImage;
     if (bgImg && bgImg !== "none" && bgImg !== "initial") {
+      // A gradient paints on top of the element's own backgroundColor, so that
+      // color is not what shows behind the text. Return null so the caller
+      // evaluates the gradient stops instead.
+      if (bgImg.includes("gradient(")) return null;
       // Background image found — composite accumulated layers over
       // the solid backgroundColor if available, otherwise return null.
       const bg = style.backgroundColor;
@@ -232,9 +236,26 @@ export function splitByComma(content: string): string[] {
 }
 
 /**
+ * Isolate the color from a gradient stop segment, dropping any trailing
+ * position. Parenthesis-aware so that `rgba(0, 0, 0, 0.5) 25%` and
+ * `color-mix(in srgb, red 50%, blue) 3em` split at the right place.
+ */
+function gradientStopColor(segment: string): string {
+  const fn = segment.match(/^[a-z-]+\(/i);
+  if (!fn) return segment.split(/\s+/)[0];
+  let depth = 0;
+  for (let i = fn[0].length - 1; i < segment.length; i++) {
+    if (segment[i] === "(") depth++;
+    else if (segment[i] === ")" && --depth === 0) return segment.slice(0, i + 1);
+  }
+  return segment;
+}
+
+/**
  * Extract color stops from a CSS gradient value.
  * Returns parsed RGB colors for each stop, skipping positions/angles.
- * For "transparent", uses the provided fallback color (defaults to white).
+ * Semi-transparent stops (including "transparent") are composited over the
+ * provided fallback, which is the color painted behind the gradient.
  */
 export function parseGradientStops(
   bgImage: string,
@@ -261,17 +282,19 @@ export function parseGradientStops(
     // Skip direction tokens like "to right", "90deg", etc.
     if (/^(to\s|[\d.]+deg|[\d.]+turn|[\d.]+rad)/i.test(trimmed)) continue;
 
+    const colorPart = gradientStopColor(trimmed);
+
     // Handle "transparent" keyword
-    if (trimmed === "transparent" || trimmed.startsWith("transparent ")) {
+    if (colorPart === "transparent") {
       colors.push(transparentFallback);
       continue;
     }
 
-    // Try parsing the full segment as a color (for simple colors like "black")
-    // or just the color part (before position like "3.3em" or "50%")
-    const colorPart = trimmed.replace(/\s+[\d.]+(%|em|px|rem|vh|vw).*$/i, "").trim();
     const parsed = parseColor(colorPart);
-    if (parsed) colors.push(parsed);
+    if (!parsed) continue;
+    const alpha = parseColorAlpha(colorPart);
+    // A translucent stop shows the color painted behind the gradient
+    colors.push(alpha < 1 ? compositeColors(parsed, transparentFallback, alpha) : parsed);
   }
   return colors;
 }


### PR DESCRIPTION
Fixes #21.

## The premise in the issue was wrong

The issue says the engine lacks gradient handling. It has had it all along: `findAncestorGradient` + `checkGradientContrast` implement ACT afw4f7 (use the stop giving the *best* contrast, flag only if even that fails). The bug was that this code was never reached.

## Root cause

`_computeEffectiveBg` walks ancestors looking for a solid background. When it found an element with a `background-image`, it returned that element's `background-color` if one was set. But a gradient paints **on top of** `background-color` — the color is a fallback for browsers that can't render the gradient, not what shows behind the text.

So for the extremely common declaration:

```css
.hero {
  background-color: #fff;                                        /* fallback */
  background-image: linear-gradient(rgb(19,19,39), rgb(40,40,80)); /* what you see */
}
```

`getEffectiveBackgroundColor` returned white. Non-null, so `checkContrast` took the solid-color path and never consulted `findAncestorGradient`. White hero text was judged white-on-white and flagged at 1:1, serious. That matches the report exactly: real contrast ~17:1, "the nearest solid background-color behind the gradient is white".

I confirmed this in Chromium before changing anything, across eight gradient shapes. Only the `background-color` + gradient shape reproduced; plain gradient ancestors, angled multi-stop gradients, and gradients on `<body>` were all already handled correctly.

## The fix

`_computeEffectiveBg` returns `null` when the background-image is a gradient, so `checkContrast` routes to the gradient path. Two gaps in that path then had to be closed, since it now receives cases it never used to see:

- `findAncestorGradient` treated *any* background-color with alpha >= 0.01 as "solid, gradient hidden" and gave up. An 8%-opaque scrim does not hide a gradient. It now accumulates translucent layers and stops only at a genuinely opaque one.
- The color behind the gradient (used for translucent stops) was read from the gradient element's *parent*, skipping the gradient element's own `background-color` — which is precisely the color this bug is about. Now resolved from the element itself first.
- `parseGradientStops` dropped stop alpha, reading `rgba(0,0,0,0.1)` as opaque black. Translucent stops are now composited over the color behind the gradient. Stop positions are split parenthesis-aware, so `rgba(0, 0, 0, 0.5) 25%` no longer mangles into `rgba(0, 0, 0, 0.5` when the position sits inside the color function's argument list.

## No new bail-outs

Per the guidance in the issue thread, this adds **zero** false negatives. Every input that previously produced a verdict still produces one; cases that previously produced a *wrong* verdict now produce a right one. The change is entirely about which color the ratio is computed against.

Blast radius is contained: `getEffectiveBackgroundColor` has exactly two non-test callers, both in `color-contrast-helpers.ts`, shared by the AA and AAA rules. Both rules' suites pass.

## On the "needs review" suggestion

Not done, deliberately. That status does not exist in this engine — `types.ts` has no incomplete/cantTell, `Violation` only has `impact`, and a rule's outcomes are "emit" or "stay silent". The only `cantTell` is in the ACT reporting layer, derived from a thrown rule error. Adding a third status is a `types.ts` + engine + every-consumer change, far too big for this issue, and unnecessary here: the gradient *is* computable, it just wasn't being read.

## Tests

10 browser tests in `core/src/integration/color-contrast.browser.test.ts` (browser, not unit — happy-dom's computed style can't exercise this). 6 of the 10 fail on `main` and pass here; the other 4 lock in shapes that already worked so they don't regress.

Verified red before green by stashing the source fix:

```
× passes: white hero text over a dark gradient painted on a white background-color
× passes: white text over an angled multi-stop dark gradient
× passes: white text nested below a wrapper inside the gradient element
× fails: dark text over a dark gradient, even at the best-contrast stop
× fails: white text over a light gradient painted on a black background-color
× fails: a translucent dark gradient over white stays too light for white text
```

Gates: 66 browser tests pass, 970 unit tests pass, `turbo run build typecheck test` clean, ACT conformance gate **PASSED** with afw4f7 examples green. The 3 `bun run lint` errors are pre-existing in `cli/src/cdp.ts`, `report/aggregate.js`, and `report/history.js` — untouched by this branch.

## Out of scope, filed separately

**Run-to-run variance (10 findings vs 1).** I checked the caches as asked: `clearAllCaches()` runs at the top of every `runAudit`, `_effectiveBgCache` is keyed per-element and deterministic within a run, and browser `CSSStyleDeclaration` objects are live. I found no ordering or staleness bug that would explain it. The variance is consistent with the audit running before the DOM settles — how many hero elements exist, and whether `mayBeOverImage`'s positioned-sibling check sees the image yet, both depend on paint timing. That's `apps/runner` in accesslint.com, as noted.

**Modern color syntax is unparsed.** Chromium leaves `oklch()`, `oklab()`, and `color(srgb ...)` unconverted in computed styles (verified). `parseColor` returns `null` for all three, which causes the *same class* of false positive as this bug: `_computeEffectiveBg` walks straight past an unparseable `background-color` and can land on the white root default. It also silently skips any element whose text `color` is `oklch()`. Tailwind v4 emits `oklch()` for its entire default palette, so this likely affects real pages today — possibly the same page in this report. It's a distinct root cause with a distinct fix (color-space conversion), so it belongs in its own PR rather than expanding this one.
