### PR TITLE
fix: clear the three eslint errors blocking `bun run lint`

### DIFF
--- a/cli/src/cdp.ts
+++ b/cli/src/cdp.ts
@@ -99,7 +99,7 @@ async function waitForExpression(
   waitFor: string,
   timeoutMs: number,
 ): Promise<void> {
-  const looksLikeSelector = /^[#.\[\]:>~+*\-_a-zA-Z0-9 ]+$/.test(waitFor) && !/\s\s/.test(waitFor);
+  const looksLikeSelector = /^[#.[\]:>~+*\-_a-zA-Z0-9 ]+$/.test(waitFor) && !/\s\s/.test(waitFor);
   const probe = looksLikeSelector
     ? `Boolean(document.querySelector(${JSON.stringify(waitFor)}))`
     : `document.body && document.body.innerText && document.body.innerText.includes(${JSON.stringify(waitFor)})`;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,13 @@ export default [
     },
   },
   {
+    // Published node10 resolution shims. @accesslint/report is "type": "module",
+    // but node10 consumers reach these paths directly and `require()` them.
+    files: ["report/aggregate.js", "report/history.js"],
+    languageOptions: { sourceType: "commonjs" },
+    rules: { "@typescript-eslint/no-require-imports": "off" },
+  },
+  {
     files: ["**/*.test.ts", "**/*.spec.ts", "**/test-helpers.ts", "**/test-setup.ts"],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",


### PR DESCRIPTION
Split out of #22, where these turned up as pre-existing failures unrelated to that fix.

`bun run lint` exits 1 on `main` with 3 errors. This clears them; the gate now exits 0.

## `cli/src/cdp.ts`

```
102:34  error  Unnecessary escape character: \[  no-useless-escape
```

The selector-detection pattern escaped `[` inside a character class, where `[` has no special meaning. Dropping the backslash leaves the regex byte-identical after unescaping, and I checked 16 inputs (ids, classes, attribute selectors, combinators, prose, unicode) through both patterns — zero behavioral differences.

The adjacent `\-` stays: unescaped it would read as a `*`–`_` range and swallow ~50 characters. ESLint correctly leaves that one alone.

## `report/aggregate.js`, `report/history.js`

```
1:18  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
```

These are the node10 resolution shims added in 0ad1cb6 to fix `attw` warnings. They're CommonJS on purpose: `@accesslint/report` is `"type": "module"` and its `exports` map points at `dist/*.cjs`, but node10 consumers bypass `exports` and resolve these root paths directly, so `module.exports = require(...)` is exactly what belongs there. Both are listed in the package's `files`, so they ship.

Rewriting them as ESM would break the case they exist to serve, so the fix is in the lint config: scope those two paths as `commonjs` and turn the rule off for them. Named explicitly rather than globbing `report/*.js`, so a future ESM file at that root still gets linted normally.

## Still failing separately

`bun run ci` runs `turbo run build typecheck test && bun run lint && bun run format:check`. Lint is green now, but **`format:check` fails on 21 files** whose formatting drifted before this branch — I verified the same 21 fail on a clean `origin/main` checkout, and neither file I touched is among them.

That's a one-line mechanical fix, but it's a wide whitespace-only diff across several packages, so I left it out rather than burying this change in it:

```bash
bun run format
```

Worth doing soon — until then `bun run ci` stays red for everyone.

## Verification

`bun run lint` exits 0 · both changed files pass `prettier --check` · `build`, `typecheck`, and `test` pass · cli suite 58 tests green.
