### PR TITLE
fix(core): treat native host-language state as satisfying required ARIA attrs

### DIFF
--- a/core/src/rules/aria/aria-required-attr.test.ts
+++ b/core/src/rules/aria/aria-required-attr.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import { ariaRequiredAttr } from "./aria-required-attr";
-import { expectViolations, expectNoViolations } from "../../test-helpers";
+import { expectViolations, expectNoViolations, makeDoc } from "../../test-helpers";
 
 const RULE_ID = "aria/aria-required-attr";
 
@@ -14,6 +14,76 @@ describe(RULE_ID, () => {
 
   it("exempts native <input type=checkbox> (implicit state)", () => {
     expectNoViolations(ariaRequiredAttr, "<html><body><input type='checkbox'></body></html>");
+  });
+
+  it("exempts checked native <input type=checkbox role=switch>", () => {
+    expectNoViolations(
+      ariaRequiredAttr,
+      "<html><body><input type='checkbox' role='switch' checked></body></html>",
+    );
+  });
+
+  it("exempts unchecked native <input type=checkbox role=switch>", () => {
+    expectNoViolations(
+      ariaRequiredAttr,
+      "<html><body><input type='checkbox' role='switch'></body></html>",
+    );
+  });
+
+  it("exempts native switch whose checked state was set via the IDL property", () => {
+    const doc = makeDoc("<html><body><input type='checkbox' role='switch'></body></html>");
+    const input = doc.querySelector("input") as HTMLInputElement;
+    input.checked = true;
+    expect(ariaRequiredAttr.run(doc)).toHaveLength(0);
+  });
+
+  it("exempts native <input type=radio role=menuitemradio>", () => {
+    expectNoViolations(
+      ariaRequiredAttr,
+      "<html><body><input type='radio' role='menuitemradio'></body></html>",
+    );
+  });
+
+  it("exempts native <input type=range role=slider>", () => {
+    expectNoViolations(
+      ariaRequiredAttr,
+      "<html><body><input type='range' role='slider'></body></html>",
+    );
+  });
+
+  it("exempts native <meter role=meter>", () => {
+    expectNoViolations(
+      ariaRequiredAttr,
+      "<html><body><meter role='meter' value='0.5'></meter></body></html>",
+    );
+  });
+
+  it("exempts native <h2 role=heading> (implicit aria-level)", () => {
+    expectNoViolations(ariaRequiredAttr, "<html><body><h2 role='heading'>Title</h2></body></html>");
+  });
+
+  it("reports <div role=switch> without aria-checked (no native state)", () => {
+    expectViolations(ariaRequiredAttr, "<html><body><div role='switch'></div></body></html>", {
+      count: 1,
+      ruleId: RULE_ID,
+      messageMatches: /aria-checked/,
+    });
+  });
+
+  it("reports <span role=switch tabindex=0> without aria-checked", () => {
+    expectViolations(
+      ariaRequiredAttr,
+      "<html><body><span role='switch' tabindex='0'>Off</span></body></html>",
+      { count: 1, ruleId: RULE_ID },
+    );
+  });
+
+  it("reports <input type=text role=switch> (text input has no checked state)", () => {
+    expectViolations(
+      ariaRequiredAttr,
+      "<html><body><input type='text' role='switch'></body></html>",
+      { count: 1, ruleId: RULE_ID },
+    );
   });
 
   it("passes non-focusable role=separator (aria-valuenow only required when focusable)", () => {
@@ -70,13 +140,6 @@ describe(RULE_ID, () => {
       "<html><body><div role='scrollbar' aria-valuenow='50'></div></body></html>",
       { count: 1, ruleId: RULE_ID },
     );
-  });
-
-  it("reports role=switch without aria-checked", () => {
-    expectViolations(ariaRequiredAttr, "<html><body><div role='switch'></div></body></html>", {
-      count: 1,
-      ruleId: RULE_ID,
-    });
   });
 
   it("reports role=spinbutton without aria-valuenow", () => {

--- a/core/src/rules/aria/aria-required-attr.ts
+++ b/core/src/rules/aria/aria-required-attr.ts
@@ -17,6 +17,25 @@ const REQUIRED_ATTRS: Record<string, string[]> = {
   switch: ["aria-checked"],
 };
 
+/**
+ * Host-language state that maps to an ARIA attribute in the accessibility tree
+ * per HTML-AAM, so an explicit ARIA attribute is not required.
+ * https://www.w3.org/TR/html-aam-1.0/#html-attribute-state-and-property-mappings
+ */
+const NATIVE_STATE: Record<string, (el: Element) => boolean> = {
+  "aria-checked": (el) =>
+    el instanceof HTMLInputElement && (el.type === "checkbox" || el.type === "radio"),
+  "aria-level": (el) => /^h[1-6]$/i.test(el.tagName),
+  "aria-selected": (el) => el instanceof HTMLOptionElement,
+  "aria-valuenow": (el) =>
+    (el instanceof HTMLInputElement && (el.type === "range" || el.type === "number")) ||
+    ["progress", "meter"].includes(el.tagName.toLowerCase()),
+};
+
+function hasNativeState(el: Element, attr: string): boolean {
+  return NATIVE_STATE[attr]?.(el) ?? false;
+}
+
 export const ariaRequiredAttr: Rule = {
   id: "aria/aria-required-attr",
   category: "aria",
@@ -37,23 +56,14 @@ export const ariaRequiredAttr: Rule = {
       const required = REQUIRED_ATTRS[role];
       if (!required) continue;
 
-      // Skip native elements that implicitly provide the state
-      if (role === "checkbox" && el instanceof HTMLInputElement && el.type === "checkbox") continue;
-      if (role === "radio" && el instanceof HTMLInputElement && el.type === "radio") continue;
-      if (role === "option" && el instanceof HTMLOptionElement) continue;
-      if (role === "heading" && /^h[1-6]$/i.test(el.tagName)) continue;
-
       // separator only requires aria-valuenow when focusable (interactive separator)
       if (role === "separator") {
         const tabindex = el.getAttribute("tabindex");
         if (!tabindex || tabindex === "-1") continue;
       }
 
-      // Native <hr> elements have implicit separator role — skip
-      if (el.tagName.toLowerCase() === "hr" && !el.hasAttribute("role")) continue;
-
       for (const attr of required) {
-        if (!el.hasAttribute(attr)) {
+        if (!el.hasAttribute(attr) && !hasNativeState(el, attr)) {
           violations.push({
             ruleId: "aria/aria-required-attr",
             selector: getSelector(el),


### PR DESCRIPTION
Fixes #17.

## The bug

`aria/aria-required-attr` flagged `<input type="checkbox" role="switch">` as missing `aria-checked`, at **critical** impact. Per [HTML-AAM](https://www.w3.org/TR/html-aam-1.0/#html-attribute-state-and-property-mappings), a checkbox input's native `checked` state maps to `aria-checked` in the accessibility tree, which satisfies the required-state semantics of `role="switch"`. axe-core fixed the same pattern in v4.4. The markup comes from a very widely deployed consent-management platform, so the false positive recurs across many customer sites.

## Generalize or keep it narrow?

**Generalized**, deliberately. The rule already carried three one-off skips (`role=checkbox` on a checkbox input, `role=radio` on a radio input, `role=heading` on `h1`-`h6`) plus two dead ones (`role=option`, and an `<hr>` guard unreachable from a `[role]` query). Those skips were keyed on the *explicit role*, which is exactly why `role="switch"` slipped through: the same native element, a different role name, and the exemption did not apply.

The replacement is an attribute-keyed table of host-language state mappings, checked per required attribute:

| ARIA attribute | Native state |
| --- | --- |
| `aria-checked` | `<input type="checkbox">`, `<input type="radio">` |
| `aria-level` | `<h1>`-`<h6>` |
| `aria-selected` | `<option>` |
| `aria-valuenow` | `<input type="range">`, `<input type="number">`, `<progress>`, `<meter>` |

This mirrors how axe-core models it (`implicitAttrs` in `lib/standards/html-elms.js`, consumed by `aria-required-attr-evaluate`), and it fixes the whole class rather than one instance: `<input type="radio" role="menuitemradio">` and `<input type="range" role="slider">` were false positives too.

One deliberate narrowing versus axe-core: axe grants implicit `aria-valuenow` to *every* input via its `default` variant, plus `<select>` and `<textarea>`. HTML-AAM does not define a value mapping for text inputs, so `<input type="text" role="spinbutton">` keeps failing here. That is covered by a test.

## What still fails

- `<div role="switch">` / `<span role="switch" tabindex="0">` with no `aria-checked`: still a violation. The exemption is tied to the native element, not the role, so authored widgets are untouched.
- `<input type="text" role="switch">`: still a violation, no native checked state.
- `aria-checked="mixed"` is not expressible natively, and `indeterminate` is a JS-only property with no mapping. The rule only checks attribute presence, so neither is silenced by this change.

## Out of scope

The report noted the flagged instances were also inside a hidden preferences panel. That visibility gate is #16 and is being handled separately, so the weak hidden check at the top of `run()` is untouched here.

## Tests

Regression tests added for: checked native switch, unchecked native switch (absence of `checked` maps to `aria-checked="false"`, still satisfied), `checked` set via the IDL property rather than the content attribute, native `menuitemradio` / `slider` / `meter` / `heading`, and the three cases above that must keep failing.

- `bun run --filter=@accesslint/core test src/rules/aria/aria-required-attr.test.ts`: 22 passed
- `bun run ci`: build, typecheck, test, and lint pass. `format:check` fails on 21 files that are pre-existing on `main` and untouched here, verified by running it against `origin/main` directly. This branch is rebased on `main` after #26, which cleared the lint errors an earlier revision of this description mentioned.
- `npx turbo run act --filter=@accesslint/core`: conformance gate PASSED, ACT 4e8ab6 at 14/14 (100%).
- Coverage thresholds pass.

