### PR TITLE
fix(core): don't flag never-rendered tags as content outside a landmark

### DIFF
--- a/core/src/rules/landmarks/region.test.ts
+++ b/core/src/rules/landmarks/region.test.ts
@@ -1,5 +1,5 @@
-import { describe, it } from "vitest";
-import { expectViolations, expectNoViolations } from "../../test-helpers";
+import { describe, it, expect } from "vitest";
+import { expectViolations, expectNoViolations, makeDoc } from "../../test-helpers";
 import { region } from "./region";
 
 const RULE_ID = "landmarks/region";
@@ -94,6 +94,81 @@ describe(RULE_ID, () => {
         </div>
       </body></html>
     `,
+    );
+  });
+
+  it("ignores a misplaced <title> in the body", () => {
+    const doc = makeDoc(`
+      <html><body>
+        <title>Page title</title>
+        <main>Content</main>
+      </body></html>
+    `);
+    // Guard the fixture: the parser must leave <title> in <body> for this to
+    // exercise the malformed-markup case from the bug report.
+    expect(Array.from(doc.body.children).map((c) => c.tagName)).toContain("TITLE");
+    expect(region.run(doc)).toEqual([]);
+  });
+
+  it("ignores non-rendered head content misplaced in the body", () => {
+    expectNoViolations(
+      region,
+      `
+      <html><body>
+        <title>Page title</title>
+        <script>console.log("x")</script>
+        <style>body { color: red }</style>
+        <meta name="description" content="d">
+        <link rel="canonical" href="/page">
+        <template><p>Template content</p></template>
+        <base href="/">
+        <main>Content</main>
+      </body></html>
+    `,
+    );
+  });
+
+  it("ignores a <noscript> the UA stylesheet hides", () => {
+    // Chrome gives <noscript> display:none whenever scripting is enabled, which
+    // is the only way we evaluate a document. happy-dom ships no UA rule for it,
+    // so the fixture supplies one; the rule reads computed style either way.
+    expectNoViolations(
+      region,
+      `
+      <html><head><style>noscript { display: none }</style></head><body>
+        <noscript>Enable JavaScript</noscript>
+        <main>Content</main>
+      </body></html>
+    `,
+    );
+  });
+
+  it("ignores a datalist, which belongs in the body but renders nothing", () => {
+    expectNoViolations(
+      region,
+      `
+      <html><body>
+        <datalist id="fruits">
+          <option value="Apple">Apple</option>
+          <option value="Banana">Banana</option>
+        </datalist>
+        <main><input list="fruits"></main>
+      </body></html>
+    `,
+    );
+  });
+
+  it("still reports rendered content alongside non-rendered tags", () => {
+    expectViolations(
+      region,
+      `
+      <html><body>
+        <title>Page title</title>
+        <div>Orphan content</div>
+        <main>Main content</main>
+      </body></html>
+    `,
+      { count: 1, ruleId: RULE_ID, selectorIncludes: "div" },
     );
   });
 });

--- a/core/src/rules/landmarks/region.ts
+++ b/core/src/rules/landmarks/region.ts
@@ -21,8 +21,6 @@ export const region: Rule = {
     // Walk through direct children of body
     for (const child of body.children) {
       if (isComputedHidden(child)) continue;
-      if (child instanceof HTMLScriptElement || child instanceof HTMLStyleElement) continue;
-      if (child.tagName === "NOSCRIPT") continue;
 
       // Skip links are allowed outside landmarks
       if (child.matches('a[href^="#"]')) continue;


### PR DESCRIPTION
Fixes #18.

## Problem

`landmarks/region` walks the direct children of `<body>` and reports any child with text content that is neither a landmark nor a landmark wrapper. It counted elements the UA stylesheet never renders, so it reported violations for content no user can perceive.

Two ways those elements reach `<body>`:

- **Malformed markup**, the case in #18: a page shipped `<title>` inside `<body>`, and the rule flagged it as "content not contained within a landmark region." It repeated on every step of every flow on the affected site.
- **Valid markup**: `<datalist>` belongs in `<body>` by design and every autocomplete input has one, yet it renders nothing while its `<option>` children carry text. This was flagged too, and is the more common of the two in practice.

## Fix

Two lines deleted.

```diff
       if (isComputedHidden(child)) continue;
-      if (child instanceof HTMLScriptElement || child instanceof HTMLStyleElement) continue;
-      if (child.tagName === "NOSCRIPT") continue;
```

#30 landed while this was open and moved the rule onto `isComputedHidden`, which reads computed style up the ancestor chain. That already answers this bug: every tag involved is `display:none` per the UA stylesheet wherever it appears. The rule's remaining inline tag checks were redundant against it, so they go too, and one check now decides what gets skipped.

This replaces the earlier approach in this PR, which added a shared `isNeverRenderedTag` predicate backed by the [HTML Rendering spec's hidden elements list](https://html.spec.whatwg.org/multipage/rendering.html#hidden-elements). Once #30 landed that predicate was carrying nothing the computed-style check did not already cover, so it is retired rather than merged alongside. `core/src/rules/utils/visibility.ts` is untouched by this PR.

## The `noscript` caveat

Worth knowing before merging, because it is a real behavior change rather than a pure cleanup.

Chrome gives `<noscript>` `display:none` whenever scripting is enabled, which is the only way the engine ever evaluates a document, so every live CDP audit is unaffected. But neither simulated DOM ships a UA rule for it. Measured directly:

| tag | happy-dom 20.9 | jsdom 26.1 | Chrome |
| --- | --- | --- | --- |
| `title`, `script`, `style`, `meta`, `link`, `template`, `base`, `datalist` | `none` | `none` | `none` |
| `noscript` | `""` | `""` | `none` |

The deleted `NOSCRIPT` check was load-bearing for that path. `matchers-internal/src/audit.ts` defaults `componentMode` to false when the audit target is `documentElement`, so `expect(document).toBeAccessible()` under `@accesslint/vitest` (happy-dom) or `@accesslint/jest` (jsdom), on a document with a body-level `<noscript>`, will now report a violation it did not before. Component-scoped audits filter out `page-level` rules and are unaffected.

If that path matters, the fix belongs in `matchers-internal` as a UA-stylesheet shim for the rules these environments omit, not as a tag list back inside the rule. Happy to file it.

## Tests

Five cases in `core/src/rules/landmarks/region.test.ts`:

- a misplaced `<title>` in `<body>` produces no violation
- a `<datalist>` with populated `<option>` children produces no violation
- the wider set of non-rendered head content in `<body>` produces no violation
- a `<noscript>` hidden by stylesheet produces no violation
- a real orphan `<div>` alongside a misplaced `<title>` still produces exactly one violation, on the `<div>`

The `<title>` test asserts the parsed fixture actually keeps `<title>` in `<body>` before running the rule, so it cannot silently pass if parser behavior changes. The `<datalist>` fixture uses `<option>` elements with text, since empty ones would pass vacuously. The `<noscript>` fixture supplies the UA rule happy-dom omits, so it exercises the computed-style path rather than asserting an outcome the environment cannot produce.

Deleting the `isComputedHidden` line fails all five, plus #30's own `display:none` test. None of them are vacuous.

## Verification

Rebased onto `main` at 7603f34.

- `bun run ci`: exit 0 end to end (build, typecheck, test, lint with 0 errors, format:check)
- `@accesslint/core`: 1066 passed across 102 files

No i18n changes needed: `description`, `guidance` and the violation message are unchanged.

## Follow-up

#18 also suggested surfacing misplaced head content as a separate document-structure diagnostic. That is a new rule rather than part of this fix, so it is filed as #28 with the open questions written up, including whether Chrome relocates the elements during parsing and leaves nothing to detect in a live-DOM audit.

One case this now covers for free, which the tag list never could: `<dialog>` without `open`. It is `display:none` by conditional UA rule, so a tag check could not see it, and the earlier revision of this PR called it out as still flagged. Both happy-dom and jsdom model that rule correctly, so it is skipped everywhere.
