### PR TITLE
Apply prettier formatting across the repo

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,6 @@
 
 # Apply prettier formatting across the repo
 8843ca20aa70cfd06e5e9e625bf7bad08d888f17
+
+# Apply prettier formatting across the repo
+f402471a7760ea2e174e8513138391c7924755d2

--- a/chrome/src/chrome.ts
+++ b/chrome/src/chrome.ts
@@ -73,7 +73,9 @@ export function resolveDownload(opts: EnsureOptions = {}): boolean {
 /** The only signal that means "the CLI can drive this Chrome." */
 async function discovery(port: number): Promise<DiscoveryInfo | null> {
   try {
-    const res = await fetch(`http://${HOST}:${port}/json/version`, { signal: AbortSignal.timeout(1000) });
+    const res = await fetch(`http://${HOST}:${port}/json/version`, {
+      signal: AbortSignal.timeout(1000),
+    });
     return res.ok ? ((await res.json()) as DiscoveryInfo) : null;
   } catch {
     return null;
@@ -127,7 +129,15 @@ export async function ensure(opts: EnsureOptions = {}): Promise<EnsureResult> {
   const download = resolveDownload(opts);
 
   const existing = await discovery(port);
-  if (existing) return { ok: true, mode: "attached", host: HOST, port, browser: existing.Browser, managed: false };
+  if (existing)
+    return {
+      ok: true,
+      mode: "attached",
+      host: HOST,
+      port,
+      browser: existing.Browser,
+      managed: false,
+    };
 
   if (pinned) {
     if (await tcpOpen(port)) {
@@ -143,7 +153,15 @@ export async function ensure(opts: EnsureOptions = {}): Promise<EnsureResult> {
   const reuse = await managedAlive();
   if (reuse) {
     const { state, info } = reuse;
-    return { ok: true, mode: "attached", host: HOST, port: state.port, browser: info.Browser, pid: state.pid, managed: true };
+    return {
+      ok: true,
+      mode: "attached",
+      host: HOST,
+      port: state.port,
+      browser: info.Browser,
+      pid: state.pid,
+      managed: true,
+    };
   }
 
   return launchOn(await freePort(port), opts.headed, download);
@@ -173,16 +191,30 @@ async function launchOn(port: number, headed = false, download = false): Promise
   if (!info) {
     killTree(pid);
     rmSync(userDataDir, { recursive: true, force: true });
-    throw new Error(`Launched Chrome (pid ${pid}) but discovery never answered on ${HOST}:${port}.`);
+    throw new Error(
+      `Launched Chrome (pid ${pid}) but discovery never answered on ${HOST}:${port}.`,
+    );
   }
 
   writeState({ pid, port, userDataDir, startedAt: new Date().toISOString() });
-  return { ok: true, mode: "launched", host: HOST, port, browser: info.Browser, pid, managed: true };
+  return {
+    ok: true,
+    mode: "launched",
+    host: HOST,
+    port,
+    browser: info.Browser,
+    pid,
+    managed: true,
+  };
 }
 
 /** Tear down instances we launched (one port, or `all`), cleaning up profiles. */
-export async function stop(opts: { port?: number; all?: boolean } = {}): Promise<StoppedInstance[]> {
-  const targets = opts.all ? listStates() : [readState(resolvePort(opts))].filter((s): s is ChromeState => s !== null);
+export async function stop(
+  opts: { port?: number; all?: boolean } = {},
+): Promise<StoppedInstance[]> {
+  const targets = opts.all
+    ? listStates()
+    : [readState(resolvePort(opts))].filter((s): s is ChromeState => s !== null);
 
   const stopped: StoppedInstance[] = [];
   for (const state of targets) {
@@ -218,15 +250,25 @@ function chromeCacheDir(): string {
 async function downloadChrome(): Promise<string> {
   const browsers = await import("@puppeteer/browsers");
   const platform = browsers.detectBrowserPlatform();
-  if (!platform) throw new Error("Could not detect a platform to download Chrome for. Set CHROME_PATH instead.");
+  if (!platform)
+    throw new Error("Could not detect a platform to download Chrome for. Set CHROME_PATH instead.");
   const cacheDir = chromeCacheDir();
 
-  const cached = (await browsers.getInstalledBrowsers({ cacheDir })).find((b) => b.browser === browsers.Browser.CHROME);
+  const cached = (await browsers.getInstalledBrowsers({ cacheDir })).find(
+    (b) => b.browser === browsers.Browser.CHROME,
+  );
   if (cached) return cached.executablePath;
 
   const buildId = await browsers.resolveBuildId(browsers.Browser.CHROME, platform, "stable");
-  process.stderr.write(`@accesslint/chrome: downloading Chrome for Testing ${buildId} to ${cacheDir} (one time, ~170MB)...\n`);
-  const installed = await browsers.install({ browser: browsers.Browser.CHROME, platform, buildId, cacheDir });
+  process.stderr.write(
+    `@accesslint/chrome: downloading Chrome for Testing ${buildId} to ${cacheDir} (one time, ~170MB)...\n`,
+  );
+  const installed = await browsers.install({
+    browser: browsers.Browser.CHROME,
+    platform,
+    buildId,
+    cacheDir,
+  });
   process.stderr.write(`@accesslint/chrome: Chrome ready at ${installed.executablePath}\n`);
   return installed.executablePath;
 }

--- a/chrome/src/cli.ts
+++ b/chrome/src/cli.ts
@@ -2,17 +2,28 @@
 import { defineCommand, runMain } from "citty";
 import { ensure, stop } from "./chrome.js";
 
-const port = { type: "string" as const, alias: "p", description: "CDP port to attach to / launch on (default 9222)" };
+const port = {
+  type: "string" as const,
+  alias: "p",
+  description: "CDP port to attach to / launch on (default 9222)",
+};
 
 function print(value: unknown): void {
   process.stdout.write(JSON.stringify(value) + "\n");
 }
 
 const ensureCmd = defineCommand({
-  meta: { name: "ensure", description: "Get-or-launch a driveable Chrome; print its CDP endpoint as JSON" },
+  meta: {
+    name: "ensure",
+    description: "Get-or-launch a driveable Chrome; print its CDP endpoint as JSON",
+  },
   args: {
     port,
-    headed: { type: "boolean", description: "Launch a visible Chrome instead of headless", default: false },
+    headed: {
+      type: "boolean",
+      description: "Launch a visible Chrome instead of headless",
+      default: false,
+    },
     download: {
       type: "boolean",
       description: "If no system Chrome is found, download a managed Chrome for Testing",
@@ -21,7 +32,13 @@ const ensureCmd = defineCommand({
   },
   async run({ args }) {
     try {
-      print(await ensure({ port: args.port ? Number(args.port) : undefined, headed: args.headed, download: args.download }));
+      print(
+        await ensure({
+          port: args.port ? Number(args.port) : undefined,
+          headed: args.headed,
+          download: args.download,
+        }),
+      );
     } catch (err) {
       print({ ok: false, error: err instanceof Error ? err.message : String(err) });
       process.exit(1);
@@ -36,13 +53,19 @@ const stopCmd = defineCommand({
     all: { type: "boolean", description: "Stop every managed instance", default: false },
   },
   async run({ args }) {
-    print({ ok: true, stopped: await stop({ port: args.port ? Number(args.port) : undefined, all: args.all }) });
+    print({
+      ok: true,
+      stopped: await stop({ port: args.port ? Number(args.port) : undefined, all: args.all }),
+    });
   },
 });
 
 runMain(
   defineCommand({
-    meta: { name: "accesslint-chrome", description: "Ensure and manage a debuggable Chrome for AccessLint live audits" },
+    meta: {
+      name: "accesslint-chrome",
+      description: "Ensure and manage a debuggable Chrome for AccessLint live audits",
+    },
     subCommands: { ensure: ensureCmd, stop: stopCmd },
   }),
 );

--- a/cli/src/format.test.ts
+++ b/cli/src/format.test.ts
@@ -33,9 +33,33 @@ describe("formatSARIF", () => {
     const { rules, results } = parse(
       formatSARIF(
         makeResult([
-          { ruleId: "a/x", selector: "#one", html: "<i>", impact: "critical", message: "m1", wcag: ["1.1.1"], level: "A" },
-          { ruleId: "a/x", selector: "#two", html: "<i>", impact: "critical", message: "m1", wcag: ["1.1.1"], level: "A" },
-          { ruleId: "b/y", selector: "#three", html: "<i>", impact: "minor", message: "m2", wcag: ["2.4.4"], level: "A" },
+          {
+            ruleId: "a/x",
+            selector: "#one",
+            html: "<i>",
+            impact: "critical",
+            message: "m1",
+            wcag: ["1.1.1"],
+            level: "A",
+          },
+          {
+            ruleId: "a/x",
+            selector: "#two",
+            html: "<i>",
+            impact: "critical",
+            message: "m1",
+            wcag: ["1.1.1"],
+            level: "A",
+          },
+          {
+            ruleId: "b/y",
+            selector: "#three",
+            html: "<i>",
+            impact: "minor",
+            message: "m2",
+            wcag: ["2.4.4"],
+            level: "A",
+          },
         ]),
         "1.0.0",
       ),
@@ -69,7 +93,15 @@ describe("formatSARIF", () => {
     const { rules } = parse(
       formatSARIF(
         makeResult([
-          { ruleId: "wcag/rule", selector: "a", html: "<i>", impact: "serious", message: "m", wcag: ["2.4.4"], level: "AA" },
+          {
+            ruleId: "wcag/rule",
+            selector: "a",
+            html: "<i>",
+            impact: "serious",
+            message: "m",
+            wcag: ["2.4.4"],
+            level: "AA",
+          },
           { ruleId: "bp/rule", selector: "b", html: "<i>", impact: "moderate", message: "m" },
         ]),
         "1.0.0",

--- a/cli/tsdown.config.ts
+++ b/cli/tsdown.config.ts
@@ -18,7 +18,9 @@ export default defineConfig([
   },
   {
     entry: ["./src/cdp-audit.ts", "./src/ssrf-guard.ts", "./src/safe-fetch.ts"],
-    deps: { neverBundle: ["@accesslint/core", "@accesslint/heal-diff", "@accesslint/matchers-internal"] },
+    deps: {
+      neverBundle: ["@accesslint/core", "@accesslint/heal-diff", "@accesslint/matchers-internal"],
+    },
     dts: true,
     publint: true,
     attw: { profile: "esm-only" },

--- a/codemod/README.md
+++ b/codemod/README.md
@@ -23,25 +23,28 @@ npx @accesslint/codemod jest-axe --dry --print 'src/**/*.test.tsx'
 
 ## Subcommands
 
-| Subcommand    | Source              | Target                 |
-| ------------- | ------------------- | ---------------------- |
-| `jest-axe`    | `jest-axe`          | `@accesslint/jest`     |
-| `vitest-axe`  | `vitest-axe`        | `@accesslint/vitest`   |
-| `jasmine-axe` | `jasmine-axe`       | `@accesslint/jest`     |
-| `auto`        | _detected from package.json_ | _per-plugin_  |
+| Subcommand    | Source                       | Target               |
+| ------------- | ---------------------------- | -------------------- |
+| `jest-axe`    | `jest-axe`                   | `@accesslint/jest`   |
+| `vitest-axe`  | `vitest-axe`                 | `@accesslint/vitest` |
+| `jasmine-axe` | `jasmine-axe`                | `@accesslint/jest`   |
+| `auto`        | _detected from package.json_ | _per-plugin_         |
 
 ## What's transformed
 
 1. **Imports** are rewritten to a side-effect import of the target package:
+
    ```diff
    - import { axe, toHaveNoViolations } from "jest-axe";
    + import "@accesslint/jest";
    ```
+
    Named, aliased, namespace, and CJS `require()` forms are all recognized.
 
 2. **`expect.extend(toHaveNoViolations)`** is removed — the side-effect import auto-registers the `toBeAccessible()` matcher. Identifier, object (`{ toHaveNoViolations }`), and spread (`{ ...toHaveNoViolations }`) forms are all handled.
 
 3. **Two-statement pattern** is collapsed:
+
    ```diff
    - const results = await axe(container);
    - expect(results).toHaveNoViolations();
@@ -64,13 +67,13 @@ npx @accesslint/codemod jest-axe --dry --print 'src/**/*.test.tsx'
 
 ## Flags
 
-| Flag                     | Default             | Meaning |
-| ------------------------ | ------------------- | ------- |
-| `--dry`                  | `false`             | Don't write files; report what would change |
-| `--print`                | `false`             | Print transformed source to stdout (use with `--dry`) |
-| `--parser=<name>`        | `tsx`               | jscodeshift parser: `babel`, `babylon`, `flow`, `ts`, `tsx` |
-| `--extensions=<csv>`     | `js,jsx,ts,tsx`     | Comma-separated list of file extensions to process |
-| `--verbose=<0\|1\|2>`    | `0`                 | Verbosity level |
+| Flag                  | Default         | Meaning                                                     |
+| --------------------- | --------------- | ----------------------------------------------------------- |
+| `--dry`               | `false`         | Don't write files; report what would change                 |
+| `--print`             | `false`         | Print transformed source to stdout (use with `--dry`)       |
+| `--parser=<name>`     | `tsx`           | jscodeshift parser: `babel`, `babylon`, `flow`, `ts`, `tsx` |
+| `--extensions=<csv>`  | `js,jsx,ts,tsx` | Comma-separated list of file extensions to process          |
+| `--verbose=<0\|1\|2>` | `0`             | Verbosity level                                             |
 
 ## After running
 

--- a/codemod/src/cli.ts
+++ b/codemod/src/cli.ts
@@ -134,9 +134,7 @@ const detectInstalledPlugins = async (): Promise<PluginKey[]> => {
   const pkg = await findNearestPackageJson(process.cwd());
   if (!pkg) return [];
   const all = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
-  return (Object.keys(plugins) as PluginKey[]).filter(
-    (key) => plugins[key].sourceModule in all,
-  );
+  return (Object.keys(plugins) as PluginKey[]).filter((key) => plugins[key].sourceModule in all);
 };
 
 type PkgJson = {

--- a/codemod/src/transforms/matcher-plugin.ts
+++ b/codemod/src/transforms/matcher-plugin.ts
@@ -122,37 +122,31 @@ const transform = (file: FileInfo, api: API, options: Options): string | null | 
   return root.toSource({ quote: "double" });
 };
 
-const collectImportedNames = (
-  j: JSCodeshift,
-  root: Collection,
-  opts: ResolvedOptions,
-): Names => {
+const collectImportedNames = (j: JSCodeshift, root: Collection, opts: ResolvedOptions): Names => {
   const names: Names = { axe: null, matcher: null, config: null };
 
-  root
-    .find(j.ImportDeclaration, { source: { value: opts.sourceModule } })
-    .forEach((path) => {
-      const specifiers = path.node.specifiers ?? [];
-      for (const spec of specifiers) {
-        if (spec.type === "ImportSpecifier") {
-          const imported = asString(spec.imported.name);
-          const local = asString(spec.local?.name) ?? imported;
-          if (!imported || !local) continue;
-          if (imported === opts.axeName) names.axe = local;
-          else if (imported === opts.matcherName) names.matcher = local;
-          else if (imported === opts.configName) names.config = local;
-        } else if (
-          spec.type === "ImportDefaultSpecifier" ||
-          spec.type === "ImportNamespaceSpecifier"
-        ) {
-          const local = asString(spec.local?.name);
-          if (local) {
-            names.axe = names.axe ?? `${local}.${opts.axeName}`;
-            names.matcher = names.matcher ?? `${local}.${opts.matcherName}`;
-          }
+  root.find(j.ImportDeclaration, { source: { value: opts.sourceModule } }).forEach((path) => {
+    const specifiers = path.node.specifiers ?? [];
+    for (const spec of specifiers) {
+      if (spec.type === "ImportSpecifier") {
+        const imported = asString(spec.imported.name);
+        const local = asString(spec.local?.name) ?? imported;
+        if (!imported || !local) continue;
+        if (imported === opts.axeName) names.axe = local;
+        else if (imported === opts.matcherName) names.matcher = local;
+        else if (imported === opts.configName) names.config = local;
+      } else if (
+        spec.type === "ImportDefaultSpecifier" ||
+        spec.type === "ImportNamespaceSpecifier"
+      ) {
+        const local = asString(spec.local?.name);
+        if (local) {
+          names.axe = names.axe ?? `${local}.${opts.axeName}`;
+          names.matcher = names.matcher ?? `${local}.${opts.matcherName}`;
         }
       }
-    });
+    }
+  });
 
   root
     .find(j.VariableDeclarator)
@@ -177,11 +171,7 @@ const collectImportedNames = (
   return names;
 };
 
-const removeExpectExtend = (
-  j: JSCodeshift,
-  root: Collection,
-  matcherLocal: string,
-): boolean => {
+const removeExpectExtend = (j: JSCodeshift, root: Collection, matcherLocal: string): boolean => {
   const calls = root.find(j.ExpressionStatement, {
     expression: {
       type: "CallExpression",
@@ -305,11 +295,7 @@ const collapseInlineAxeAssert = (
   return changed;
 };
 
-const matchesMatcherCall = (
-  node: Node,
-  resultVar: string,
-  matcherLocal: string,
-): boolean => {
+const matchesMatcherCall = (node: Node, resultVar: string, matcherLocal: string): boolean => {
   if (node.type !== "ExpressionStatement") return false;
   const expr = (node as ExpressionStatement).expression;
   if (expr.type !== "CallExpression") return false;
@@ -350,10 +336,7 @@ const buildTargetCall = (
   targetMatcher: string,
 ): CallExpression => {
   const expectCall = j.callExpression(j.identifier("expect"), [target]);
-  const call = j.callExpression(
-    j.memberExpression(expectCall, j.identifier(targetMatcher)),
-    [],
-  );
+  const call = j.callExpression(j.memberExpression(expectCall, j.identifier(targetMatcher)), []);
   if (hadExtraArgs) {
     const comment = j.commentLine(
       ` ${TODO_PREFIX} original axe() options not auto-migrated; re-apply via ${targetMatcher}({ disabledRules, failOn, ... })`,
@@ -390,24 +373,22 @@ const rewriteImports = (
   let changed = false;
   const hasConfig = Boolean(names.config);
 
-  root
-    .find(j.ImportDeclaration, { source: { value: opts.sourceModule } })
-    .forEach((path) => {
-      const node = path.node;
-      if (hasConfig) {
-        const kept = (node.specifiers ?? []).filter((spec) => {
-          if (spec.type !== "ImportSpecifier") return false;
-          return spec.imported.name === opts.configName;
-        });
-        if (kept.length === (node.specifiers?.length ?? 0)) return;
-        node.specifiers = kept;
-        changed = true;
-      } else {
-        const sideEffect = j.importDeclaration([], j.literal(opts.targetModule));
-        j(path).replaceWith(sideEffect);
-        changed = true;
-      }
-    });
+  root.find(j.ImportDeclaration, { source: { value: opts.sourceModule } }).forEach((path) => {
+    const node = path.node;
+    if (hasConfig) {
+      const kept = (node.specifiers ?? []).filter((spec) => {
+        if (spec.type !== "ImportSpecifier") return false;
+        return spec.imported.name === opts.configName;
+      });
+      if (kept.length === (node.specifiers?.length ?? 0)) return;
+      node.specifiers = kept;
+      changed = true;
+    } else {
+      const sideEffect = j.importDeclaration([], j.literal(opts.targetModule));
+      j(path).replaceWith(sideEffect);
+      changed = true;
+    }
+  });
 
   if (hasConfig) {
     const anySource = root.find(j.ImportDeclaration, { source: { value: opts.sourceModule } });

--- a/core/src/i18n/es.ts
+++ b/core/src/i18n/es.ts
@@ -39,7 +39,8 @@ export const es: LocaleMap = {
     },
   },
   "labels-and-names/frame-focusable-content": {
-    description: "Los iframes con contenido interactivo no deben excluirse del orden de tabulación.",
+    description:
+      "Los iframes con contenido interactivo no deben excluirse del orden de tabulación.",
     guidance:
       'Un <iframe> con tabindex="-1" elimina el marco del orden de tabulación, pero los elementos enfocables dentro permanecen accesibles con teclas de flecha en algunos navegadores y son inaccesibles en otros. Elimine tabindex="-1" del iframe, o agregue tabindex="-1" a cada elemento enfocable dentro de él. Si el marco es decorativo, agregue aria-hidden="true" en su lugar.',
     messages: {

--- a/core/src/rules/distinguishable/letter-spacing.ts
+++ b/core/src/rules/distinguishable/letter-spacing.ts
@@ -12,9 +12,9 @@ export const letterSpacing: Rule = {
   guidance:
     "WCAG 1.4.12 requires users to be able to override text spacing. Using !important on letter-spacing with a value below 0.12em prevents this. Either increase the value to at least 0.12em or remove !important.",
   applicable: (doc) =>
-    Array.from(
-      doc.querySelectorAll('[style*="letter-spacing"][style*="!important"]'),
-    ).some((el) => (el.textContent?.trim().length ?? 0) > 0),
+    Array.from(doc.querySelectorAll('[style*="letter-spacing"][style*="!important"]')).some(
+      (el) => (el.textContent?.trim().length ?? 0) > 0,
+    ),
   run(doc) {
     return checkTextSpacing(doc, "distinguishable/letter-spacing", "letter-spacing", 0.12);
   },

--- a/core/src/rules/distinguishable/line-height.ts
+++ b/core/src/rules/distinguishable/line-height.ts
@@ -22,9 +22,9 @@ export const lineHeight: Rule = {
   guidance:
     "WCAG 1.4.12 requires users to be able to override text spacing. Using !important on line-height with a value below 1.5 prevents this. Either increase the value to at least 1.5 or remove !important.",
   applicable: (doc) =>
-    Array.from(
-      doc.querySelectorAll('[style*="line-height"][style*="!important"]'),
-    ).some((el) => (el.textContent?.trim().length ?? 0) > 0),
+    Array.from(doc.querySelectorAll('[style*="line-height"][style*="!important"]')).some(
+      (el) => (el.textContent?.trim().length ?? 0) > 0,
+    ),
   run(doc) {
     const violations: {
       ruleId: string;

--- a/core/src/rules/distinguishable/word-spacing.ts
+++ b/core/src/rules/distinguishable/word-spacing.ts
@@ -12,9 +12,9 @@ export const wordSpacing: Rule = {
   guidance:
     "WCAG 1.4.12 requires users to be able to override text spacing. Using !important on word-spacing with a value below 0.16em prevents this. Either increase the value to at least 0.16em or remove !important.",
   applicable: (doc) =>
-    Array.from(
-      doc.querySelectorAll('[style*="word-spacing"][style*="!important"]'),
-    ).some((el) => (el.textContent?.trim().length ?? 0) > 0),
+    Array.from(doc.querySelectorAll('[style*="word-spacing"][style*="!important"]')).some(
+      (el) => (el.textContent?.trim().length ?? 0) > 0,
+    ),
   run(doc) {
     return checkTextSpacing(doc, "distinguishable/word-spacing", "word-spacing", 0.16);
   },

--- a/core/src/rules/labels-and-names/aria-command-name.ts
+++ b/core/src/rules/labels-and-names/aria-command-name.ts
@@ -13,9 +13,8 @@ export const ariaCommandName: Rule = {
   guidance:
     "Interactive ARIA command roles (button, link, menuitem) must have accessible names so users know what action they perform. Add visible text content, aria-label, or aria-labelledby to provide a name.",
   applicable: (doc) =>
-    doc.querySelector(
-      '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]',
-    ) !== null,
+    doc.querySelector('[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]') !==
+    null,
   run(doc) {
     const violations = [];
 

--- a/core/src/rules/labels-and-names/form-label.ts
+++ b/core/src/rules/labels-and-names/form-label.ts
@@ -117,9 +117,9 @@ export const formLabel: Rule = {
   guidance:
     "Every form input needs an accessible label so users understand what information to enter. Use a <label> element with a for attribute matching the input's id, wrap the input in a <label>, or use aria-label/aria-labelledby for custom components. Placeholders are not sufficient as labels since they disappear when typing. Labels should describe the information requested, not the field type (e.g., 'Email address', 'Search', 'Phone number').",
   applicable: (doc) =>
-    Array.from(
-      doc.querySelectorAll('input:not([type="hidden"]), select, textarea'),
-    ).some((el) => (el as HTMLElement).style?.display !== "none"),
+    Array.from(doc.querySelectorAll('input:not([type="hidden"]), select, textarea')).some(
+      (el) => (el as HTMLElement).style?.display !== "none",
+    ),
   run(doc) {
     const violations = [];
 

--- a/core/src/rules/labels-and-names/frame-focusable-content.ts
+++ b/core/src/rules/labels-and-names/frame-focusable-content.ts
@@ -18,7 +18,7 @@ export const frameFocusableContent: Rule = {
   fixability: "mechanical",
   description: "Iframes with interactive content must not be excluded from the tab order.",
   guidance:
-    "An <iframe> with tabindex=\"-1\" removes the frame itself from the tab order, but focusable elements inside remain reachable with arrow keys on some browsers and are unreachable on others. Remove tabindex=\"-1\" from the iframe, or add tabindex=\"-1\" to every focusable element inside it. If the frame is decorative, add aria-hidden=\"true\" instead.",
+    'An <iframe> with tabindex="-1" removes the frame itself from the tab order, but focusable elements inside remain reachable with arrow keys on some browsers and are unreachable on others. Remove tabindex="-1" from the iframe, or add tabindex="-1" to every focusable element inside it. If the frame is decorative, add aria-hidden="true" instead.',
   applicable: (doc) => doc.querySelector('iframe[tabindex="-1"]') !== null,
   run(doc) {
     const violations = [];

--- a/core/src/rules/utils/generated-id.test.ts
+++ b/core/src/rules/utils/generated-id.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { isGeneratedId, isStableId } from "./generated-id";
-import {
-  getSelector,
-  extractAnchor,
-  buildRelativeLocation,
-  clearSelectorCache,
-} from "./selector";
+import { getSelector, extractAnchor, buildRelativeLocation, clearSelectorCache } from "./selector";
 import { makeDoc } from "../../test-helpers";
 
 afterEach(() => clearSelectorCache());

--- a/core/src/sourcemap/react-fiber.test.ts
+++ b/core/src/sourcemap/react-fiber.test.ts
@@ -70,7 +70,9 @@ function makeViolation(element?: Element): Violation {
 
 function attachFiber(node: Element, fiber: unknown): void {
   // Mirror React's internal naming: __reactFiber$<random>
-  (node as unknown as Record<string, unknown>)[`__reactFiber$${Math.random().toString(36).slice(2)}`] = fiber;
+  (node as unknown as Record<string, unknown>)[
+    `__reactFiber$${Math.random().toString(36).slice(2)}`
+  ] = fiber;
 }
 
 /**
@@ -159,7 +161,11 @@ describe("attachReactFiberSource", () => {
     (Component as unknown as { displayName: string }).displayName = "ProductCard";
     attachFiber(el, {
       type: Component,
-      _debugSource: { fileName: "/src/components/ProductCard.tsx", lineNumber: 42, columnNumber: 7 },
+      _debugSource: {
+        fileName: "/src/components/ProductCard.tsx",
+        lineNumber: 42,
+        columnNumber: 7,
+      },
     });
 
     const v = makeViolation(el);
@@ -381,7 +387,9 @@ describe("attachReactFiberSource", () => {
         "fetch",
         vi.fn(async (url: string | URL) => {
           if (String(url) === chunkUrl) {
-            return new Response("(function(){})();\n//# sourceMappingURL=app.js.map\n", { status: 200 });
+            return new Response("(function(){})();\n//# sourceMappingURL=app.js.map\n", {
+              status: 200,
+            });
           }
           if (String(url) === mapUrl) {
             return new Response(map, { status: 200 });
@@ -455,7 +463,9 @@ describe("attachReactFiberSource", () => {
         "fetch",
         vi.fn(async (url: string | URL) => {
           if (String(url) === chunkUrl) {
-            return new Response(`(function(){})();\n//# sourceMappingURL=${dataUrl}\n`, { status: 200 });
+            return new Response(`(function(){})();\n//# sourceMappingURL=${dataUrl}\n`, {
+              status: 200,
+            });
           }
           return new Response("", { status: 404 });
         }),

--- a/core/src/sourcemap/react-fiber.ts
+++ b/core/src/sourcemap/react-fiber.ts
@@ -250,10 +250,7 @@ async function locationFor(
   return null;
 }
 
-async function resolveFromFiber(
-  fiber: FiberLike,
-  cache: ResolverCache,
-): Promise<SourceLocation[]> {
+async function resolveFromFiber(fiber: FiberLike, cache: ResolverCache): Promise<SourceLocation[]> {
   const out: SourceLocation[] = [];
 
   const self = await locationFor(fiber, 0, cache);

--- a/core/src/sourcemap/source-map.test.ts
+++ b/core/src/sourcemap/source-map.test.ts
@@ -46,11 +46,7 @@ function encodeMappings(decoded: number[][][]): string {
     .join(";");
 }
 
-function flatMap(opts: {
-  sources: string[];
-  names?: string[];
-  segments: number[][][];
-}): string {
+function flatMap(opts: { sources: string[]; names?: string[]; segments: number[][][] }): string {
   return JSON.stringify({
     version: 3,
     sources: opts.sources,
@@ -147,7 +143,9 @@ describe("parseSourceMap + originalPositionFor", () => {
   });
 
   describe("sectioned (indexed) maps", () => {
-    function sectionedMap(sections: { offset: { line: number; column: number }; map: object }[]): string {
+    function sectionedMap(
+      sections: { offset: { line: number; column: number }; map: object }[],
+    ): string {
       return JSON.stringify({ version: 3, sections });
     }
 
@@ -241,9 +239,7 @@ describe("parseSourceMap + originalPositionFor", () => {
 
     it("returns null on malformed VLQ", () => {
       expect(
-        parseSourceMap(
-          JSON.stringify({ version: 3, sources: ["x"], names: [], mappings: "@@@@" }),
-        ),
+        parseSourceMap(JSON.stringify({ version: 3, sources: ["x"], names: [], mappings: "@@@@" })),
       ).toBeNull();
     });
   });

--- a/core/src/sourcemap/source-map.ts
+++ b/core/src/sourcemap/source-map.ts
@@ -199,7 +199,7 @@ function resolveFlat(m: FlatMap, line: number, column: number): OriginalPosition
     source,
     line: seg[2] + 1,
     column: seg[3],
-    name: seg.length === 5 ? m.names[seg[4]] ?? null : null,
+    name: seg.length === 5 ? (m.names[seg[4]] ?? null) : null,
   };
 }
 
@@ -219,10 +219,7 @@ export function originalPositionFor(
     const queryLine0 = line - 1;
     let chosen: SectionedMap["sections"][number] | null = null;
     for (const s of m.sections) {
-      if (
-        s.offsetLine < queryLine0 ||
-        (s.offsetLine === queryLine0 && s.offsetCol <= column)
-      ) {
+      if (s.offsetLine < queryLine0 || (s.offsetLine === queryLine0 && s.offsetCol <= column)) {
         chosen = s;
       } else {
         break;
@@ -232,8 +229,7 @@ export function originalPositionFor(
     // Inner map's local line/column = query minus section offset. The first
     // line of the section is also the only one where the column offset applies.
     const localLine = queryLine0 - chosen.offsetLine + 1; // 1-based
-    const localCol =
-      queryLine0 === chosen.offsetLine ? column - chosen.offsetCol : column;
+    const localCol = queryLine0 === chosen.offsetLine ? column - chosen.offsetCol : column;
     return resolveFlat(chosen.map, localLine, localCol);
   }
   return resolveFlat(m, line, column);

--- a/heal-diff/docs/RFC-multi-signal-healing.md
+++ b/heal-diff/docs/RFC-multi-signal-healing.md
@@ -4,7 +4,7 @@ Status: implemented in this PR. Package: `@accesslint/heal-diff`. Consumers: `@a
 
 ## Problem
 
-Snapshot baselines identify accessibility violations by `ruleId + selector`. Under jsdom / happy-dom the selector is a tag-path like `html > body > div:nth-of-type(2) > img`. Any DOM refactor (wrapping an element, reordering siblings, renaming an ancestor) breaks the selector even when the violation is unchanged. The matcher then reports it as one *fixed* baseline entry plus one *new* violation. Healing is automatic only when no new violation appears, and the developer pays a mental tax distinguishing "same issue, different selector" from "genuinely new issue". At scale a single shared-component change can ripple as N new violations across N snapshots with no indication they share a root cause.
+Snapshot baselines identify accessibility violations by `ruleId + selector`. Under jsdom / happy-dom the selector is a tag-path like `html > body > div:nth-of-type(2) > img`. Any DOM refactor (wrapping an element, reordering siblings, renaming an ancestor) breaks the selector even when the violation is unchanged. The matcher then reports it as one _fixed_ baseline entry plus one _new_ violation. Healing is automatic only when no new violation appears, and the developer pays a mental tax distinguishing "same issue, different selector" from "genuinely new issue". At scale a single shared-component change can ripple as N new violations across N snapshots with no indication they share a root cause.
 
 ## Non-goals
 
@@ -18,14 +18,14 @@ Snapshot baselines identify accessibility violations by `ruleId + selector`. Und
 
 Each violation is fingerprinted with a bag of orthogonal signals. No single signal is authoritative; each survives a different kind of change.
 
-| Signal              | Survives...                                      | Cost to compute |
-|---------------------|--------------------------------------------------|-----------------|
-| `selector`          | nothing below — baseline assumption              | near zero       |
-| `anchor`            | DOM restructure (as long as the attr stays)      | O(1) per elem   |
-| `role`              | tag swap with same ARIA role + name              | O(depth) ARIA   |
-| `visualFingerprint` | CSS + DOM churn that doesn't move pixels         | screenshot + hash |
-| `htmlFingerprint`   | move, rename ancestors, attribute churn (class/style/id dropped) | O(200) hash |
-| `relativeLocation`  | wrapper insertion, class churn                   | O(depth) walk   |
+| Signal              | Survives...                                                      | Cost to compute   |
+| ------------------- | ---------------------------------------------------------------- | ----------------- |
+| `selector`          | nothing below — baseline assumption                              | near zero         |
+| `anchor`            | DOM restructure (as long as the attr stays)                      | O(1) per elem     |
+| `role`              | tag swap with same ARIA role + name                              | O(depth) ARIA     |
+| `visualFingerprint` | CSS + DOM churn that doesn't move pixels                         | screenshot + hash |
+| `htmlFingerprint`   | move, rename ancestors, attribute churn (class/style/id dropped) | O(200) hash       |
+| `relativeLocation`  | wrapper insertion, class churn                                   | O(depth) walk     |
 
 `anchor` uses the project's existing priority list (`data-testid` → `id` → `name` → `href` → `for` → `aria-label`). `role` joins `getComputedRole(el)` with `getAccessibleName(el)` to avoid two same-role elements collapsing. `htmlFingerprint` hashes a normalized HTML snippet (drop `class`/`style`/generated ids, lowercase tags, sort attributes, truncate text, SHA-1, keep 12 hex chars). `relativeLocation` walks to the nearest landmark ancestor and adds a short sibling-text anchor.
 
@@ -54,7 +54,7 @@ When tiers 2–6 match, the baseline entry is replaced in memory with the curren
 
 T1 carries `verifiedBy: htmlFingerprint`: when both items have a fingerprint and the values disagree, the pair is refused and both items are released to the tiers below (refuse-and-release). Release alone is not enough. `data-testid` is both the `anchor` signal and — since it is Playwright's default `testIdAttribute` — the `selector`, so for any element carrying one the anchor tier keys on exactly the information T1 just rejected, and re-pairs the impostor unverified one tier later. That is a silent false heal on the most common anchor attribute in the wild.
 
-So a refusal is remembered for the run: **these two items are not the same element**, which stays true at every weaker tier, and no later tier may pair them. The alternatives were both worse. Sending a refused *item* straight to `new` breaks the swapped-elements case, where two elements are refused at T1 and must still heal to their true partners at T5 — the refusal is a fact about the pair, not about either item. Adding `verifiedBy` tier by tier is whack-a-mole that terminates only when every tier verifies, which is a global fingerprint gate: it would refuse the legitimate "anchored element moved *and* its markup churned" case, precisely what the anchor tier exists to survive.
+So a refusal is remembered for the run: **these two items are not the same element**, which stays true at every weaker tier, and no later tier may pair them. The alternatives were both worse. Sending a refused _item_ straight to `new` breaks the swapped-elements case, where two elements are refused at T1 and must still heal to their true partners at T5 — the refusal is a fact about the pair, not about either item. Adding `verifiedBy` tier by tier is whack-a-mole that terminates only when every tier verifies, which is a global fingerprint gate: it would refuse the legitimate "anchored element moved _and_ its markup churned" case, precisely what the anchor tier exists to survive.
 
 Refusal memory is keyed on object identity, not signal values — matching is count-based, so two items with identical signals are distinct items and value-keying would refuse both when only one was refused. The uniqueness gate keeps counting raw bucket length, refusals included, which preserves the invariant that **a refusal can only ever subtract a heal, never create one**. Pairs still unresolved at the end of the run surface as `DiffResult.refused` with the disagreeing signal name, and the matcher renders them in place of the "likely moved" hint (§4).
 
@@ -99,7 +99,7 @@ export function evaluateSnapshot(
 
 ## Validation strategy
 
-Cheapest first. The risk we bound is *silent false heal* (accepting a real regression as "same issue moved").
+Cheapest first. The risk we bound is _silent false heal_ (accepting a real regression as "same issue moved").
 
 1. Synthetic fixture corpus: ~30 `(before, after, expected)` DOM pairs covering wrapper insertion, sibling reorder, ancestor rename, anchor swap, text change, genuine new. Unit-test level.
 2. Property tests (fast-check): `htmlFingerprint` invariant under whitespace + attr-reorder, `relativeLocation` invariant under wrapper insertion, `extractAnchor` priority order.
@@ -116,7 +116,7 @@ Cheapest first. The risk we bound is *silent false heal* (accepting a real regre
 
 ## Known limitation: an impostor that reuses a non-selector anchor
 
-Refusals originate at T1, so the hole closes only where the pair actually meets there. For `data-testid` that is always, since the selector *is* the test id. For an anchor the selector doesn't encode, it isn't:
+Refusals originate at T1, so the hole closes only where the pair actually meets there. For `data-testid` that is always, since the selector _is_ the test id. For an anchor the selector doesn't encode, it isn't:
 
 ```
 baseline: getByRole('img').first()  anchor data-id=hero  fp aaa

--- a/matchers-internal/src/signals.test.ts
+++ b/matchers-internal/src/signals.test.ts
@@ -40,9 +40,7 @@ describe("buildRelativeLocation", () => {
   });
 
   it("picks the intermediate crumb closest to the element", () => {
-    mount(
-      `<main><div id="outer"><div id="inner"><div><img></div></div></div></main>`,
-    );
+    mount(`<main><div id="outer"><div id="inner"><div><img></div></div></div></main>`);
     const img = find(document.body, "img");
     const out = buildRelativeLocation(img);
     expect(out).toContain("div#inner");


### PR DESCRIPTION
Follow-up to #26, which cleared the lint errors but left `format:check` red.

`bun run ci` runs `turbo run build typecheck test && bun run lint && bun run format:check`. That last step failed on 21 files whose formatting had drifted, so the gate was red for anyone running it locally regardless of what they'd changed. **`bun run ci` now exits 0.**

## What's in here

Two commits, deliberately separate:

1. **f402471** — the output of `bun run format`, nothing else.
2. **b8f0583** — adds f402471 to `.git-blame-ignore-revs`.

## Not a behavior change

Formatting only. Prettier reflows, it doesn't rewrite: every string literal is byte-identical. I checked the two files where that mattered most:

- `core/src/i18n/es.ts` — only a `description:` value moved onto its own line. The string is unchanged, so the byte-comparison in `i18n.test.ts` still holds.
- `codemod/src/transforms/matcher-plugin.ts` — the largest diff (99 lines) and entirely call-chain and parameter-list re-wrapping.

Verified by the full gate: `build`, `typecheck`, `test`, `lint`, and `format:check` all pass.

## Blame

The repo already had `.git-blame-ignore-revs` with the previous formatting pass (8843ca2), so this follows that convention. Confirmed it works — a line reflowed by this PR still blames to its original commit and author:

```
cabddbbe (Cameron Cundiff 2026-04-26 ... 42)     description:
```

GitHub's web UI honors the file automatically. Locally it's once per clone:

```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

## One merge caveat

Please merge this with a **merge commit, not a squash**. `.git-blame-ignore-revs` names f402471 by SHA; squashing would rewrite it and silently break the entry. That matches how #26 and the rest of the history were merged.
