### PR TITLE
fix(core): anchor child-invalid findings to the list, not the stray child

### DIFF
--- a/core/src/rules/adaptable/definition-list.test.ts
+++ b/core/src/rules/adaptable/definition-list.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import { expectViolations, expectNoViolations } from "../../test-helpers";
 import { definitionList } from "./definition-list";
 
@@ -14,6 +14,16 @@ describe(RULE_ID, () => {
       count: 1,
       ruleId: RULE_ID,
     });
+  });
+
+  it("anchors the violation to the dl, not to the offending child", () => {
+    const violations = expectViolations(
+      definitionList,
+      "<html><body><section><dl><p>Bad</p></dl></section></body></html>",
+      { count: 1, ruleId: RULE_ID },
+    );
+    expect(violations[0].element?.tagName).toBe("DL");
+    expect(violations[0].message).toContain("<p>");
   });
 
   it("reports bare text node in dl", () => {

--- a/core/src/rules/adaptable/list-children.test.ts
+++ b/core/src/rules/adaptable/list-children.test.ts
@@ -1,8 +1,22 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import { expectViolations, expectNoViolations } from "../../test-helpers";
 import { listChildren } from "./list-children";
 
 const RULE_ID = "adaptable/list-children";
+
+/** A mega-menu panel: wrapper <div>s nested a few levels around inner <ul>s. */
+function megaMenu(panelInner: string): string {
+  return `<html><body><header><nav class="site-nav">
+    <ul class="nav__list">
+      <li class="nav__item">
+        <button aria-expanded="false">Products</button>
+        <div class="mega-menu"><div class="mega-menu__inner"><div class="mega-menu__col">
+          ${panelInner}
+        </div></div></div>
+      </li>
+    </ul>
+  </nav></header></body></html>`;
+}
 
 describe(RULE_ID, () => {
   it("passes valid ul", () => {
@@ -14,6 +28,49 @@ describe(RULE_ID, () => {
       count: 1,
       ruleId: RULE_ID,
     });
+  });
+
+  it("reports stray <span> children directly inside a ul", () => {
+    const violations = expectViolations(
+      listChildren,
+      "<html><body><ul><li>A</li><span>Stray</span></ul></body></html>",
+      { count: 1, ruleId: RULE_ID, messageMatches: /<span>/ },
+    );
+    expect(violations[0].element?.tagName).toBe("UL");
+  });
+
+  it("anchors the violation to the list, not to the offending child", () => {
+    const violations = expectViolations(
+      listChildren,
+      "<html><body><ul class='menu'><div class='promo'>Bad</div></ul></body></html>",
+      { count: 1, ruleId: RULE_ID },
+    );
+    expect(violations[0].element?.tagName).toBe("UL");
+    expect(violations[0].html).toContain("<ul");
+    expect(violations[0].message).toContain("<div>");
+  });
+
+  it("passes a mega-menu whose wrapper divs contain only valid lists", () => {
+    expectNoViolations(
+      listChildren,
+      megaMenu(
+        `<ul class="menu-list"><li><a href="/a">A</a></li><li><a href="/b">B</a></li></ul>
+         <ul class="menu-list"><li><a href="/c">C</a></li></ul>`,
+      ),
+    );
+  });
+
+  it("anchors a mega-menu violation to the offending ul, not the wrapper div", () => {
+    const violations = expectViolations(
+      listChildren,
+      megaMenu(
+        `<ul class="menu-list"><div class="promo">Promo</div><li><a href="/a">A</a></li></ul>`,
+      ),
+      { count: 1, ruleId: RULE_ID },
+    );
+    expect(violations[0].element?.tagName).toBe("UL");
+    expect(violations[0].element?.getAttribute("class")).toBe("menu-list");
+    expect(violations[0].selector).not.toMatch(/> div$/);
   });
 
   it("reports bare text node in ul", () => {

--- a/core/src/rules/engine.ts
+++ b/core/src/rules/engine.ts
@@ -285,14 +285,16 @@ export function compileDeclarativeRule(spec: DeclarativeRule): Rule {
               if (childRole && allowedRoleSet?.has(childRole)) continue;
               // Allow role="presentation" / role="none" children (pass-through containers)
               if (childRole === "presentation" || childRole === "none") continue;
+              // Anchor to the container — it owns the semantics being violated.
+              // The message names the offending child via {{tag}}.
               violations.push({
                 ruleId: spec.id,
-                selector: getSelector(child),
-                html: getHtmlSnippet(child),
+                selector: getSelector(el),
+                html: getHtmlSnippet(el),
                 impact: spec.impact,
                 message: applyTemplate(spec.message, child, spec.check),
                 fix: spec.fix,
-                element: child,
+                element: el,
               });
               break; // one violation per parent
             }

--- a/source/src/audit.test.ts
+++ b/source/src/audit.test.ts
@@ -55,7 +55,10 @@ describe("the cases the extensions were removed over", () => {
 
     expect(ruleIds(result)).toContain("adaptable/list-children");
     const finding = result.findings.find((f) => f.ruleId === "adaptable/list-children");
-    expect(finding?.line).toBe(6);
+    // The finding lands on the <ul> that owns the list semantics, not on the
+    // stray <div> at line 6; the message names the offending child.
+    expect(finding?.line).toBe(4);
+    expect(finding?.message).toContain("<div>");
   });
 });
 

--- a/source/src/audit.ts
+++ b/source/src/audit.ts
@@ -7,7 +7,6 @@ import { nonDomRenderer, testFile } from "./scope";
 import {
   attributeDependencies,
   CHILD_DEPENDENT_RULES,
-  CONTAINER_MEMBER_RULES,
   DEPENDS_ON_ANY_UNKNOWN,
   DIRECT_CHILD_RULES,
   DOC_ORDER_DEPENDENT_RULES,
@@ -15,6 +14,7 @@ import {
   HTML_ELEMENT_RULE,
   NAME_FAMILY_RULES,
   SOURCE_MODE_DISABLED_RULES,
+  TABLE_CONTAINER_RULES,
 } from "./semantics";
 import type {
   AuditSourceOptions,
@@ -282,23 +282,9 @@ function attributeUnknown(meta: NodeMeta, ruleId: string): SourceUnknown | null 
 
 /** Which element a rule reads the contents of: the subject, or its container. */
 function containerFor(ruleId: string, element: Element): Element | null {
-  const member = CONTAINER_MEMBER_RULES[ruleId];
-  if (!member) return element;
-
-  // The bare-text branch reports the container itself, and the only way to tell
-  // that apart from a member report is the text: a container is the subject when
-  // it holds text of its own.
-  const tag = element.tagName.toLowerCase();
-  if (member.containerTags.includes(tag) && hasDirectText(element)) return element;
-
-  return member.ancestor === "parent" ? element.parentElement : element.closest("table");
-}
-
-function hasDirectText(element: Element): boolean {
-  for (const node of element.childNodes) {
-    if (node.nodeType === 3 && node.textContent && node.textContent.trim()) return true;
-  }
-  return false;
+  // Container integrity rules report the container itself. Only the table rules
+  // report a cell and read the table around it.
+  return TABLE_CONTAINER_RULES.has(ruleId) ? element.closest("table") : element;
 }
 
 /**
@@ -330,9 +316,8 @@ function unprovable(
   if (attributes) return attributes;
 
   if (CHILD_DEPENDENT_RULES.has(violation.ruleId)) {
-    // Most of these rules report the container itself; the container-member
-    // rules report the offending child, and then it is the container's unknowns
-    // that decide.
+    // Most of these rules report the container itself; the table rules report a
+    // cell, and then it is the surrounding table's unknowns that decide.
     const containerElement = containerFor(violation.ruleId, element);
     const container = containerElement ? metaByElement.get(containerElement) : undefined;
     if (!container) {

--- a/source/src/semantics.ts
+++ b/source/src/semantics.ts
@@ -115,25 +115,15 @@ export const CHILD_DEPENDENT_RULES = new Set([
 ]);
 
 /**
- * The child-dependent rules that report the offending *member* rather than the
- * container, and where the container is. `list-children` reports the stray
- * `<div>`, not the `<ul>` that holds it, so it is the `<ul>`'s unknowns that
- * decide whether the finding stands.
+ * The child-dependent rules that report a *cell* rather than the container whose
+ * contents decide the verdict. `td-has-header` reports the `<td>`, but it is the
+ * surrounding `<table>`'s unknowns that decide whether the finding stands.
  *
- * `containerTags` is the other half. These rules have a second branch that
- * reports the container itself — for bare text directly inside a list — and then
- * the element in hand already *is* the container. `<ol><Link>Text</Link></ol>`
- * lands there: the text came from a component, so the container's own unknowns
- * are the ones that matter.
+ * The container integrity rules (`list-children`, `definition-list`) are not
+ * here: they report the `<ul>`/`<dl>` itself, so the element in hand already is
+ * the container.
  */
-export const CONTAINER_MEMBER_RULES: Record<
-  string,
-  { ancestor: "parent" | "table"; containerTags: string[] }
-> = {
-  "adaptable/list-children": { ancestor: "parent", containerTags: ["ul", "ol"] },
-  "adaptable/definition-list": { ancestor: "parent", containerTags: ["dl"] },
-  "adaptable/td-has-header": { ancestor: "table", containerTags: ["table"] },
-};
+export const TABLE_CONTAINER_RULES = new Set(["adaptable/td-has-header"]);
 
 /** Rules that resolve an accessible name, which any descendant can supply. */
 function nameFromContentRules(): string[] {


### PR DESCRIPTION
Fixes #19.

## Diagnosis

Reproduced before changing anything. Two candidate causes were on the table; the first is the real one.

**The `child-invalid` case anchored to the wrong node.** `core/src/rules/engine.ts` built the violation from the offending *child* (`getSelector(child)`, `element: child`). For `adaptable/list-children` on a mega-menu whose JS moves a panel wrapper into the nav `<ul>`, the finding came out anchored to a plain `<div class="mega-menu">` with selector `ul > div`. Opening that finding shows a `div > ul > li` subtree that is completely valid, so a genuine violation reads as a false positive on a non-list element.

The violation itself was real: the `<ul>` had a `<div>` direct child. Only the anchor was wrong, which is exactly what the issue describes.

Confirmed with a repro of the mega-menu shape (wrapper `<div>`s nested a few levels around inner `<ul>`s):
- a clean mega-menu produces **zero** violations, so the rule was never firing on valid structure
- a mega-menu with one stray `<div>` inside an inner `<ul>` produced a violation whose `element` was `DIV.promo`, not the `<ul>`

**`getSelector` was not the cause.** In every mega-menu repro the generated selector resolved back to the exact node the rule reported (`resolvesToSameNode: true`, `matchCount: 1`). `backfillElements()` in `core/src/rules/index.ts` is also not involved: it only fills `violation.element` when it is unset, and this path always sets it.

## What changed

`child-invalid` now reports the container that owns the semantics being violated. The message still names the offending child through the existing `{{tag}}` template, so no message text changed and no i18n update was needed.

This also makes the check internally consistent: the bare-text branch of `child-invalid` already reported the container.

## On "re-verify the target node still fails at snapshot time"

Skipped deliberately, per the diagnosis. `rule.run(doc)` is fully synchronous over a single `Document`: violations are pushed and returned inside one traversal, with no gap between evaluating a node and reporting it. A re-verify guard there would re-read the identical DOM and is a provable no-op. If a page is mid-initialization when `runAudit` is called, the fix is on the caller's side (when the audit runs), not an engine-level recheck. The reported symptom is fully explained by the anchoring bug, so no transient-DOM change is warranted.

## Blast radius

`child-invalid` is shared, so this affects every rule using it. There are exactly two:

- `adaptable/list-children` (the reported rule)
- `adaptable/definition-list` (same shape, same confusion mode: it reported the stray child instead of the `<dl>`)

Both now anchor to their container. All other declarative rules (`aria/aria-hidden-body`, `enough-time/blink`, `enough-time/marquee`, `keyboard-accessible/server-image-map`, `keyboard-accessible/tabindex`) use other check types and are untouched.

One downstream consumer needed a matching change. `@accesslint/source` had explicit machinery (`CONTAINER_MEMBER_RULES`, `containerFor`) built on the assumption that these two rules report the child and that it must walk to `.parentElement` to find the container. With the anchor corrected that walk went one level too far and suppressed real findings as `external-container`. Since these rules now report the container directly, that entry collapses to the one rule that genuinely reports a cell and reads its table, so `CONTAINER_MEMBER_RULES` becomes `TABLE_CONTAINER_RULES` and the `hasDirectText` heuristic (which existed only to tell the container-reporting branch apart from the child-reporting branch) is no longer needed. `CONTAINER_MEMBER_RULES` was internal, not exported from `source/src/index.ts`, so this is not an API break.

Note for consumers: violation selectors are snapshot identity keys (`matchers-internal/src/snapshot.ts:407`), so existing baselines containing `list-children` or `definition-list` findings will show those entries move from the child to the container.

## Tests

Added to `core/src/rules/adaptable/list-children.test.ts`:
- a clean mega-menu (wrapper `<div>`s nested a few levels around `<ul>`s of only `<li>`) reports nothing
- a mega-menu with a stray `<div>` inside an inner `<ul>` anchors to that `<ul>`, not the wrapper
- direct anchoring assertions on `element`, `html`, and `selector`
- the genuine stray-`<span>`-inside-`<ul>` case from the issue, now explicit, asserting it still fires and anchors to the `<ul>`

Added a matching anchoring test for `adaptable/definition-list`, and updated the `@accesslint/source` line-attribution test: the finding now lands on the `<ul>` rather than the stray `<div>`.

## Verification

- `bun run --filter=@accesslint/core test`: 975 passed
- `npx turbo run build typecheck test`: 39/39 tasks successful across all packages
- `bun run --filter=@accesslint/core test:coverage`: 993 passed, statements 81.68 / branches 73.92 / functions 82.65 / lines 86.27, all above the 80/70/80/80 thresholds
- `npx turbo run act --filter=@accesslint/core`: conformance gate PASSED

`bun run ci` also runs `lint` and `format:check`, which fail on this repo before any of my changes (3 lint errors in `report/*.js`, 21 unformatted files). Verified identical on a stashed clean tree; my files are lint- and format-clean.