### PR TITLE
fix(core): resolve CSS Color 4 functions instead of walking past them

### DIFF
--- a/core/src/bundle.test.ts
+++ b/core/src/bundle.test.ts
@@ -25,7 +25,9 @@ if (!existsSync(bundlePath)) {
  * a size increase is justified — surprise regressions fail CI.
  */
 const SIZE_BUDGETS: Record<string, { raw: number; gzip: number }> = {
-  "index.iife.js": { raw: 185_000, gzip: 50_000 },
+  // gzip bumped 50_000 → 52_000 for CSS Color 4 conversion (oklch/oklab/lab/
+  // lch/color), measured at +1296 bytes gzipped over the prior 48_803.
+  "index.iife.js": { raw: 185_000, gzip: 52_000 },
   "index.cjs": { raw: 410_000, gzip: 100_000 },
   "index.js": { raw: 410_000, gzip: 100_000 },
   "index.d.ts": { raw: 15_500, gzip: 5_500 },

--- a/core/src/integration/color-contrast.browser.test.ts
+++ b/core/src/integration/color-contrast.browser.test.ts
@@ -438,3 +438,81 @@ describe("gradient backgrounds", () => {
     expectNoViolations(run());
   });
 });
+
+describe("modern color syntax", () => {
+  it("passes: white text on a dark oklch() background", () => {
+    // Regression for #23: an unparseable background-color was skipped, and the
+    // ancestor walk continued to the white root default.
+    setContent(`
+      <style>
+        body { background: #fff }
+        .panel { background-color: oklch(0.2 0.03 280); padding: 40px }
+        .panel h1 { color: #fff }
+      </style>
+      <div class="panel"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("fails: near-white oklch() text on white is no longer silently skipped", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        p { color: oklch(0.95 0.01 250) }
+      </style>
+      <p>Barely visible</p>
+    `);
+    expectViolation(run(), "p");
+  });
+
+  it("fails: white text on a light oklch() gradient", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .hero {
+          background-image: linear-gradient(oklch(0.95 0.01 250), oklch(0.98 0.01 250));
+          padding: 40px;
+        }
+        .hero h1 { color: #fff }
+      </style>
+      <div class="hero"><h1>Ship accessible software</h1></div>
+    `);
+    expectViolation(run(), "h1");
+  });
+
+  it("passes: white text on a dark color(display-p3) background", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .panel { background-color: color(display-p3 0.08 0.08 0.15); padding: 40px }
+        .panel h1 { color: #fff }
+      </style>
+      <div class="panel"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("passes: white text on a dark lab() background", () => {
+    setContent(`
+      <style>
+        body { background: #fff }
+        .panel { background-color: lab(12 3 -14); padding: 40px }
+        .panel h1 { color: #fff }
+      </style>
+      <div class="panel"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+
+  it("composites a translucent oklch() layer over what sits behind it", () => {
+    setContent(`
+      <style>
+        body { background: #000 }
+        .scrim { background-color: oklch(1 0 0 / 0.04); padding: 40px }
+        .scrim h1 { color: #fff }
+      </style>
+      <div class="scrim"><h1>Ship accessible software</h1></div>
+    `);
+    expectNoViolations(run());
+  });
+});

--- a/core/src/integration/color-spaces.browser.test.ts
+++ b/core/src/integration/color-spaces.browser.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { parseColorFunction } from "../rules/utils/color-spaces";
+
+/**
+ * Ground truth: paint the color with Chrome's own pipeline and read the sRGB
+ * pixel back. Guards the conversion matrices against drift far better than
+ * hand-copied expected values.
+ */
+function browserRgb(value: string): [number, number, number] {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = 1;
+  const ctx = canvas.getContext("2d", { colorSpace: "srgb" })!;
+  ctx.fillStyle = value;
+  ctx.fillRect(0, 0, 1, 1);
+  const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+  return [r, g, b];
+}
+
+const CASES = [
+  "oklch(0.5 0.1 250)",
+  "oklch(0.2 0.03 280)",
+  "oklch(0.95 0.01 250)",
+  "oklch(0.7 0.2 30)",
+  "oklch(0 0 0)",
+  "oklch(1 0 0)",
+  "oklch(50% 0.1 250)",
+  "oklch(0.6 40% 120)",
+  "oklch(0.5 0.1 0.5turn)",
+  "oklch(0.5 none 250)",
+  "oklab(0.5 -0.1 0.05)",
+  "oklab(0.539974 0.0962086 -0.0928316)",
+  "lab(50 40 30)",
+  "lab(100 0 0)",
+  "lab(50% 40 30)",
+  "lch(50 40 30)",
+  "lch(80 60 180)",
+  "color(srgb 0.5 0 0.5)",
+  "color(srgb 1 1 1)",
+  "color(srgb-linear 0.5 0.5 0.5)",
+  "color(display-p3 0.3 0.4 0.5)",
+  "color(display-p3 1 0 0)",
+  "color(xyz 0.2 0.3 0.4)",
+  "color(xyz-d50 0.2 0.3 0.4)",
+];
+
+describe("color-spaces conversion matches the browser", () => {
+  for (const value of CASES) {
+    it(`converts ${value}`, () => {
+      const parsed = parseColorFunction(value);
+      expect(parsed, `${value} should parse`).not.toBeNull();
+      expect(parsed!.rgb).toEqual(browserRgb(value));
+    });
+  }
+
+  it("leaves out-of-gamut colors clamped the way the browser clamps them", () => {
+    // oklch(0.7 0.2 30) is outside sRGB; red clips to 255.
+    expect(parseColorFunction("oklch(0.7 0.2 30)")!.rgb).toEqual(browserRgb("oklch(0.7 0.2 30)"));
+  });
+});

--- a/core/src/rules/utils/color-spaces.test.ts
+++ b/core/src/rules/utils/color-spaces.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { parseColorFunction } from "./color-spaces";
+import { parseColor, parseColorAlpha } from "./color";
+
+/**
+ * Expected values are Chrome's own output, captured by painting each color to
+ * a canvas and reading the pixel back. color-spaces.browser.test.ts re-checks
+ * them against the live browser.
+ */
+describe("parseColorFunction", () => {
+  describe("oklch", () => {
+    it.each([
+      ["oklch(0.5 0.1 250)", [50, 102, 154]],
+      ["oklch(0.2 0.03 280)", [19, 20, 35]],
+      ["oklch(0.95 0.01 250)", [234, 239, 245]],
+      ["oklch(0 0 0)", [0, 0, 0]],
+      ["oklch(1 0 0)", [255, 255, 255]],
+    ])("converts %s", (input, expected) => {
+      expect(parseColorFunction(input as string)!.rgb).toEqual(expected);
+    });
+
+    it("accepts a percentage lightness", () => {
+      expect(parseColorFunction("oklch(50% 0.1 250)")!.rgb).toEqual(
+        parseColorFunction("oklch(0.5 0.1 250)")!.rgb,
+      );
+    });
+
+    it("accepts a percentage chroma against the 0.4 reference range", () => {
+      expect(parseColorFunction("oklch(0.6 40% 120)")!.rgb).toEqual([117, 140, 0]);
+    });
+
+    it.each([
+      ["oklch(0.5 0.1 180deg)", "oklch(0.5 0.1 180)"],
+      ["oklch(0.5 0.1 0.5turn)", "oklch(0.5 0.1 180)"],
+      ["oklch(0.5 0.1 200grad)", "oklch(0.5 0.1 180)"],
+    ])("treats %s as %s", (input, equivalent) => {
+      expect(parseColorFunction(input)!.rgb).toEqual(parseColorFunction(equivalent)!.rgb);
+    });
+
+    it("treats `none` as zero", () => {
+      expect(parseColorFunction("oklch(0.5 none 250)")!.rgb).toEqual([99, 99, 99]);
+    });
+
+    it("clamps out-of-gamut channels into sRGB", () => {
+      expect(parseColorFunction("oklch(0.7 0.2 30)")!.rgb).toEqual([255, 97, 77]);
+    });
+  });
+
+  describe("oklab", () => {
+    it.each([
+      ["oklab(0.5 -0.1 0.05)", [32, 117, 68]],
+      ["oklab(0.539974 0.0962086 -0.0928316)", [140, 83, 162]],
+    ])("converts %s", (input, expected) => {
+      expect(parseColorFunction(input as string)!.rgb).toEqual(expected);
+    });
+  });
+
+  describe("lab and lch (D50)", () => {
+    it.each([
+      ["lab(50 40 30)", [187, 88, 70]],
+      ["lab(100 0 0)", [255, 255, 255]],
+      ["lab(50% 40 30)", [187, 88, 70]],
+      ["lch(50 40 30)", [178, 93, 87]],
+      ["lch(80 60 180)", [0, 227, 196]],
+    ])("converts %s", (input, expected) => {
+      expect(parseColorFunction(input as string)!.rgb).toEqual(expected);
+    });
+  });
+
+  describe("color()", () => {
+    it.each([
+      ["color(srgb 0.5 0 0.5)", [128, 0, 128]],
+      ["color(srgb 1 1 1)", [255, 255, 255]],
+      ["color(srgb-linear 0.5 0.5 0.5)", [188, 188, 188]],
+      ["color(display-p3 0.3 0.4 0.5)", [69, 103, 130]],
+      ["color(display-p3 1 0 0)", [255, 0, 0]],
+      ["color(xyz 0.2 0.3 0.4)", [0, 167, 164]],
+      ["color(xyz-d65 0.2 0.3 0.4)", [0, 167, 164]],
+      ["color(xyz-d50 0.2 0.3 0.4)", [0, 168, 189]],
+    ])("converts %s", (input, expected) => {
+      expect(parseColorFunction(input as string)!.rgb).toEqual(expected);
+    });
+
+    it("returns null for color spaces it cannot convert", () => {
+      expect(parseColorFunction("color(rec2020 0.2 0.3 0.4)")).toBeNull();
+      expect(parseColorFunction("color(prophoto-rgb 0.2 0.3 0.4)")).toBeNull();
+    });
+  });
+
+  describe("alpha", () => {
+    it.each([
+      ["oklch(0.5 0.1 250 / 0.5)", 0.5],
+      ["oklch(0.5 0.1 250 / 50%)", 0.5],
+      ["color(srgb 0.5 0 0.5 / 0.4)", 0.4],
+      ["oklch(0.5 0.1 250)", 1],
+      ["oklch(0.5 0.1 250 / none)", 1],
+    ])("reads alpha from %s", (input, expected) => {
+      expect(parseColorFunction(input as string)!.alpha).toBe(expected);
+    });
+
+    it("does not let alpha change the resolved rgb", () => {
+      expect(parseColorFunction("oklch(0.5 0.1 250 / 0.5)")!.rgb).toEqual(
+        parseColorFunction("oklch(0.5 0.1 250)")!.rgb,
+      );
+    });
+  });
+
+  describe("non-matching input", () => {
+    it.each([
+      "rgb(1, 2, 3)",
+      "#abcdef",
+      "red",
+      "transparent",
+      "",
+      "oklch()",
+      "oklch(0.5 0.1)",
+      "not-a-color(1 2 3)",
+    ])("returns null for %s", (input) => {
+      expect(parseColorFunction(input)).toBeNull();
+    });
+  });
+});
+
+describe("parseColor integration", () => {
+  it("resolves modern color functions", () => {
+    expect(parseColor("oklch(0.2 0.03 280)")).toEqual([19, 20, 35]);
+    expect(parseColor("color(display-p3 1 0 0)")).toEqual([255, 0, 0]);
+    expect(parseColor("lab(50 40 30)")).toEqual([187, 88, 70]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseColor("OKLCH(0.2 0.03 280)")).toEqual([19, 20, 35]);
+  });
+
+  it("still resolves the legacy formats", () => {
+    expect(parseColor("rgb(19, 19, 39)")).toEqual([19, 19, 39]);
+    expect(parseColor("#131327")).toEqual([19, 19, 39]);
+    expect(parseColor("white")).toEqual([255, 255, 255]);
+  });
+
+  it("still returns null for genuinely unparseable values", () => {
+    expect(parseColor("not-a-color")).toBeNull();
+    expect(parseColor("color(rec2020 0.2 0.3 0.4)")).toBeNull();
+  });
+});
+
+describe("parseColorAlpha integration", () => {
+  it("reads alpha from modern color functions", () => {
+    expect(parseColorAlpha("oklch(0.5 0.1 250 / 0.5)")).toBe(0.5);
+    expect(parseColorAlpha("color(srgb 0.5 0 0.5 / 40%)")).toBe(0.4);
+  });
+
+  it("defaults to opaque", () => {
+    expect(parseColorAlpha("oklch(0.5 0.1 250)")).toBe(1);
+    expect(parseColorAlpha("rgb(1, 2, 3)")).toBe(1);
+  });
+
+  it("still reads legacy alpha", () => {
+    expect(parseColorAlpha("rgba(0, 0, 0, 0.25)")).toBe(0.25);
+    expect(parseColorAlpha("rgb(0 0 0 / 50%)")).toBe(0.5);
+  });
+});

--- a/core/src/rules/utils/color-spaces.ts
+++ b/core/src/rules/utils/color-spaces.ts
@@ -1,0 +1,206 @@
+/**
+ * CSS Color 4 color functions, converted to sRGB.
+ *
+ * Chromium resolves hsl() and hwb() to rgb() in computed styles but leaves
+ * oklch(), oklab(), lab(), lch(), and color() as authored, so contrast checks
+ * have to resolve them. Percentage and `none` forms are handled too: DOM-only
+ * runtimes echo the authored value back rather than normalizing it.
+ */
+
+type RGB = [number, number, number];
+type Matrix = [RGB, RGB, RGB];
+
+/** CSS uses a D50 white point for lab() and lch(). */
+const D50_WHITE: RGB = [0.3457 / 0.3585, 1, (1 - 0.3457 - 0.3585) / 0.3585];
+
+const XYZ_D50_TO_LINEAR_SRGB: Matrix = [
+  [3.13413596, -1.61738633, -0.490661946],
+  [-0.978795503, 1.91625457, 0.0334427312],
+  [0.0719553799, -0.228976826, 1.40538606],
+];
+
+const XYZ_D65_TO_LINEAR_SRGB: Matrix = [
+  [3.24096994, -1.53738318, -0.49861076],
+  [-0.969243636, 1.8759675, 0.0415550574],
+  [0.0556300797, -0.203976959, 1.05697151],
+];
+
+const LINEAR_P3_TO_LINEAR_SRGB: Matrix = [
+  [1.22494018, -0.224940176, 0],
+  [-0.0420569548, 1.04205695, 0],
+  [-0.0196375546, -0.0786360656, 1.09827362],
+];
+
+function apply(m: Matrix, [x, y, z]: RGB): RGB {
+  return [
+    m[0][0] * x + m[0][1] * y + m[0][2] * z,
+    m[1][0] * x + m[1][1] * y + m[1][2] * z,
+    m[2][0] * x + m[2][1] * y + m[2][2] * z,
+  ];
+}
+
+/** sRGB transfer function, also used by display-p3. */
+function encodeGamma(c: number): number {
+  const v = c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(Math.abs(c), 1 / 2.4) - 0.055;
+  return Math.round(Math.max(0, Math.min(1, v)) * 255);
+}
+
+function decodeGamma(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function toRgb(linear: RGB): RGB {
+  return [encodeGamma(linear[0]), encodeGamma(linear[1]), encodeGamma(linear[2])];
+}
+
+function oklabToLinearSrgb(L: number, a: number, b: number): RGB {
+  const l = (L + 0.396337777 * a + 0.215803757 * b) ** 3;
+  const m = (L - 0.105561346 * a - 0.0638541728 * b) ** 3;
+  const s = (L - 0.0894841775 * a - 1.29148555 * b) ** 3;
+  return [
+    4.07674166 * l - 3.30771159 * m + 0.230969929 * s,
+    -1.268438 * l + 2.6097574 * m - 0.341319396 * s,
+    -0.0041960863 * l - 0.703418615 * m + 1.7076147 * s,
+  ];
+}
+
+function labToXyzD50(L: number, a: number, b: number): RGB {
+  const KAPPA = 24389 / 27;
+  const EPSILON = 216 / 24389;
+  const fy = (L + 16) / 116;
+  const fx = a / 500 + fy;
+  const fz = fy - b / 200;
+  const x = fx ** 3 > EPSILON ? fx ** 3 : (116 * fx - 16) / KAPPA;
+  const y = L > KAPPA * EPSILON ? fy ** 3 : L / KAPPA;
+  const z = fz ** 3 > EPSILON ? fz ** 3 : (116 * fz - 16) / KAPPA;
+  return [x * D50_WHITE[0], y * D50_WHITE[1], z * D50_WHITE[2]];
+}
+
+/** Resolve a channel token, mapping percentages onto the channel's range. */
+function channel(token: string | undefined, percentRef: number): number | null {
+  if (token === undefined) return null;
+  if (token === "none") return 0;
+  const value = parseFloat(token);
+  if (Number.isNaN(value)) return null;
+  return token.endsWith("%") ? (value / 100) * percentRef : value;
+}
+
+function hueDegrees(token: string | undefined): number | null {
+  if (token === undefined) return null;
+  if (token === "none") return 0;
+  const value = parseFloat(token);
+  if (Number.isNaN(value)) return null;
+  if (token.endsWith("turn")) return value * 360;
+  if (token.endsWith("grad")) return value * 0.9;
+  if (token.endsWith("rad")) return (value * 180) / Math.PI;
+  return value;
+}
+
+function alphaValue(token: string | null): number {
+  if (token === null || token === "none") return 1;
+  const value = parseFloat(token);
+  if (Number.isNaN(value)) return 1;
+  return Math.max(0, Math.min(1, token.endsWith("%") ? value / 100 : value));
+}
+
+function polarToRectangular(chroma: number, hue: number): [number, number] {
+  const radians = (hue * Math.PI) / 180;
+  return [chroma * Math.cos(radians), chroma * Math.sin(radians)];
+}
+
+function colorSpaceToRgb(space: string, c: RGB): RGB | null {
+  switch (space) {
+    case "srgb":
+      return [
+        Math.round(Math.max(0, Math.min(1, c[0])) * 255),
+        Math.round(Math.max(0, Math.min(1, c[1])) * 255),
+        Math.round(Math.max(0, Math.min(1, c[2])) * 255),
+      ];
+    case "srgb-linear":
+      return toRgb(c);
+    case "display-p3":
+      return toRgb(
+        apply(LINEAR_P3_TO_LINEAR_SRGB, [decodeGamma(c[0]), decodeGamma(c[1]), decodeGamma(c[2])]),
+      );
+    case "xyz":
+    case "xyz-d65":
+      return toRgb(apply(XYZ_D65_TO_LINEAR_SRGB, c));
+    case "xyz-d50":
+      return toRgb(apply(XYZ_D50_TO_LINEAR_SRGB, c));
+    default:
+      // a98-rgb, prophoto-rgb, rec2020 and any future space
+      return null;
+  }
+}
+
+export interface ParsedColorFunction {
+  rgb: RGB;
+  alpha: number;
+}
+
+/**
+ * Parse oklch(), oklab(), lab(), lch(), or color() into sRGB.
+ * Returns null for any other syntax, so callers can fall through.
+ */
+export function parseColorFunction(value: string): ParsedColorFunction | null {
+  const match = value
+    .trim()
+    .toLowerCase()
+    .match(/^(oklch|oklab|lch|lab|color)\((.*)\)$/s);
+  if (!match) return null;
+
+  const [main, alphaToken = null] = match[2].split("/");
+  const tokens = main
+    .trim()
+    .split(/[\s,]+/)
+    .filter(Boolean);
+  const alpha = alphaValue(alphaToken === null ? null : alphaToken.trim());
+
+  let rgb: RGB | null = null;
+  switch (match[1]) {
+    case "oklab": {
+      const L = channel(tokens[0], 1);
+      const a = channel(tokens[1], 0.4);
+      const b = channel(tokens[2], 0.4);
+      if (L === null || a === null || b === null) return null;
+      rgb = toRgb(oklabToLinearSrgb(L, a, b));
+      break;
+    }
+    case "oklch": {
+      const L = channel(tokens[0], 1);
+      const c = channel(tokens[1], 0.4);
+      const h = hueDegrees(tokens[2]);
+      if (L === null || c === null || h === null) return null;
+      const [a, b] = polarToRectangular(c, h);
+      rgb = toRgb(oklabToLinearSrgb(L, a, b));
+      break;
+    }
+    case "lab": {
+      const L = channel(tokens[0], 100);
+      const a = channel(tokens[1], 125);
+      const b = channel(tokens[2], 125);
+      if (L === null || a === null || b === null) return null;
+      rgb = toRgb(apply(XYZ_D50_TO_LINEAR_SRGB, labToXyzD50(L, a, b)));
+      break;
+    }
+    case "lch": {
+      const L = channel(tokens[0], 100);
+      const c = channel(tokens[1], 150);
+      const h = hueDegrees(tokens[2]);
+      if (L === null || c === null || h === null) return null;
+      const [a, b] = polarToRectangular(c, h);
+      rgb = toRgb(apply(XYZ_D50_TO_LINEAR_SRGB, labToXyzD50(L, a, b)));
+      break;
+    }
+    case "color": {
+      const c0 = channel(tokens[1], 1);
+      const c1 = channel(tokens[2], 1);
+      const c2 = channel(tokens[3], 1);
+      if (c0 === null || c1 === null || c2 === null) return null;
+      rgb = colorSpaceToRgb(tokens[0], [c0, c1, c2]);
+      break;
+    }
+  }
+
+  return rgb ? { rgb, alpha } : null;
+}

--- a/core/src/rules/utils/color.ts
+++ b/core/src/rules/utils/color.ts
@@ -1,4 +1,5 @@
 import { getWindow } from "./dom";
+import { parseColorFunction } from "./color-spaces";
 
 let _computedStyleCache = new WeakMap<Element, CSSStyleDeclaration>();
 let _effectiveBgCache = new WeakMap<Element, [number, number, number] | null>();
@@ -102,7 +103,10 @@ export function parseColor(color: string): [number, number, number] | null {
   if (space) {
     return [parseInt(space[1]), parseInt(space[2]), parseInt(space[3])];
   }
-  return null;
+
+  // oklch() / oklab() / lab() / lch() / color() — Chromium leaves these
+  // unconverted in computed styles.
+  return parseColorFunction(trimmed)?.rgb ?? null;
 }
 
 /**
@@ -119,7 +123,8 @@ export function parseColorAlpha(color: string): number {
     const val = modern[1];
     return val.endsWith("%") ? parseFloat(val) / 100 : parseFloat(val);
   }
-  return 1.0;
+  // oklch(l c h / a), color(srgb r g b / a), and friends
+  return parseColorFunction(color.trim().toLowerCase())?.alpha ?? 1.0;
 }
 
 /**


### PR DESCRIPTION
Fixes #23. Follow-up to #22 — same false-positive symptom, different root cause.

## The gap

Chromium resolves `hsl()` and `hwb()` to `rgb()` in computed styles, but leaves these as authored. Probed in Chrome:

```
color: oklch(0.5 0.1 250)                 → "oklch(0.5 0.1 250)"
color: color-mix(in srgb, red 50%, blue)  → "color(srgb 0.5 0 0.5)"
color: lab(50% 40 30)                     → "lab(50 40 30)"
color: hwb(120 20% 30%)                   → "rgb(51, 179, 51)"     ← already fine
```

`parseColor` returned `null` for the first three. Two consequences, both reproduced before I wrote any fix:

**False positive.** `_computeEffectiveBg` treats an unparseable `background-color` as absent and continues up the ancestor chain — often all the way to the white root default. A dark `oklch()` panel with white text resolved to `effectiveBg=[255,255,255]` and was flagged **white-on-white at 1:1, serious**. Same shape as #21.

**False negative.** `checkContrast` skips any element whose text `color` won't parse, so `oklch()` text was never checked. Near-white `oklch()` text on white produced zero violations.

Tailwind v4 emits `oklch()` for its entire default palette, so both are live on current sites.

## The fix

New `core/src/rules/utils/color-spaces.ts` converting to sRGB:

| syntax | path |
|---|---|
| `oklch()`, `oklab()` | oklab → linear sRGB |
| `lab()`, `lch()` | Lab → XYZ D50 → linear sRGB |
| `color(srgb\|srgb-linear\|display-p3\|xyz\|xyz-d65\|xyz-d50 …)` | per-space matrix |

Percentages, `none`, and `turn`/`grad`/`rad` hues are handled — DOM-only runtimes (happy-dom, jsdom) echo authored values back unnormalized, so the jest/vitest matcher packages see those forms.

`a98-rgb`, `prophoto-rgb`, and `rec2020` still return `null`, and unsupported input falls through exactly as before. **No new bail-outs** — this only turns `null` into a real color.

## Verified against the browser, not against my own arithmetic

Hand-checking conversion matrices is how subtle color bugs get shipped, so I didn't. Each color is painted to a 1×1 canvas with Chrome's own pipeline and the sRGB pixel read back:

```
oklch(0.2 0.03 280)            truth=[19,20,35]    mine=[19,20,35]    Δ=0
lch(80 60 180)                 truth=[0,227,196]   mine=[0,227,196]   Δ=0
color(display-p3 0.3 0.4 0.5)  truth=[69,103,130]  mine=[69,103,130]  Δ=0
color(xyz-d50 0.2 0.3 0.4)     truth=[0,168,189]   mine=[0,168,189]   Δ=0
...
worst channel delta: 0 | cases over 1: 0
```

**24 cases, zero deviation on every channel** — including percentage channels, `none`, `0.5turn`, and out-of-gamut clamping. That comparison is kept as a permanent browser test (`color-spaces.browser.test.ts`), so the matrices can't drift silently. The unit tests use those same verified values, so they run without a browser.

## Bundle budget bumped, deliberately

`index.iife.js` gzip: **50_000 → 52_000**.

I measured the cost rather than guessing: building with the conversion stripped out gives 48_803 gzipped, with it 50_099 — **1296 bytes, 2.7%**. The budget had drifted to only ~1200 bytes of headroom, so any change of this size would have tripped it.

I first cut every float literal to 9 significant figures (8-bit output needs ~4), which saved 155 bytes and left the browser comparison at Δ=0. That wasn't enough to fit. The alternative was dropping `xyz`/`display-p3`/`srgb-linear` to squeeze under, but that reintroduces the exact false positive this PR removes for those spaces. `SIZE_BUDGETS` says to bump deliberately when justified, so I bumped it and recorded the measurement in a comment above the entry.

## Tests

- 6 end-to-end browser tests for the reported failure modes — **5 fail without the fix**, verified by disabling the conversion and re-running. The 6th (translucent `oklch()` scrim) passes either way; it's there to lock in compositing.
- 25 browser tests comparing against Chrome.
- 49 unit tests covering conversions, percentage/`none`/hue-unit forms, alpha, unsupported spaces, and that the legacy formats still parse.

Gates: `bun run ci` exits 0 · 97 browser tests · 1046 unit tests · **ACT conformance PASSED**, `distinguishable/color-contrast (afw4f7) 32 30 0 100.0% OK`.
