### PR TITLE
fix(core): disambiguate selectors when siblings share an anchor attribute

### DIFF
--- a/core/src/rules/utils/selector.test.ts
+++ b/core/src/rules/utils/selector.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getSelector, clearSelectorCache } from "./selector";
+import { makeDoc } from "../../test-helpers";
+
+afterEach(() => clearSelectorCache());
+
+/** Assert every element's selector resolves back to that same element. */
+function expectResolvable(doc: Document, elements: Iterable<Element>): string[] {
+  const selectors: string[] = [];
+  for (const el of elements) {
+    const selector = getSelector(el);
+    selectors.push(selector);
+    expect(doc.querySelectorAll(selector), selector).toHaveLength(1);
+    expect(doc.querySelector(selector), selector).toBe(el);
+  }
+  return selectors;
+}
+
+describe("getSelector uniqueness", () => {
+  it("disambiguates siblings that share an anchor attribute value", () => {
+    const doc = makeDoc(
+      `<nav>
+        <div aria-label="Menu"><ul><div class="promo">P1</div></ul></div>
+        <div aria-label="Menu"><ul><div class="promo">P2</div></ul></div>
+      </nav>`,
+    );
+    const selectors = expectResolvable(doc, doc.querySelectorAll(".promo"));
+    expect(new Set(selectors).size).toBe(2);
+  });
+
+  it("disambiguates a radio group sharing one name", () => {
+    const doc = makeDoc(
+      `<fieldset>
+        <input type="radio" name="color" value="red">
+        <input type="radio" name="color" value="green">
+        <input type="radio" name="color" value="blue">
+      </fieldset>`,
+    );
+    const selectors = expectResolvable(doc, doc.querySelectorAll("input"));
+    expect(new Set(selectors).size).toBe(3);
+  });
+
+  it("disambiguates repeated links sharing one href", () => {
+    const doc = makeDoc(
+      `<ul>
+        <li><a href="/docs"><span>Docs</span></a></li>
+        <li><a href="/docs"><span>Documentation</span></a></li>
+      </ul>`,
+    );
+    expectResolvable(doc, doc.querySelectorAll("a, a > span"));
+  });
+});
+
+describe("getSelector stability", () => {
+  it("keeps an attribute segment positional-free when the value is unique", () => {
+    const doc = makeDoc(`<nav><div aria-label="Main"><a href="/a">A</a></div></nav>`);
+    expect(getSelector(doc.querySelector("a")!)).toBe(`div[aria-label="Main"] > a[href="/a"]`);
+  });
+
+  // An ancestor with a duplicated anchor value is only worth pinning down when
+  // the descendant's own path is ambiguous. Tightening it unconditionally
+  // would trade a stable attribute path for a brittle positional one.
+  it("leaves an ancestor unpinned when the descendant path already resolves", () => {
+    const doc = makeDoc(
+      `<nav>
+        <div aria-label="Menu"><a href="/a">A</a></div>
+        <div aria-label="Menu"><a href="/b">B</a></div>
+      </nav>`,
+    );
+    const selectors = expectResolvable(doc, doc.querySelectorAll("a"));
+    for (const selector of selectors) expect(selector).not.toContain("nth-of-type");
+  });
+
+  it("prefers a stable id over the positional path", () => {
+    const doc = makeDoc(
+      `<main>
+        <div aria-label="Row" id="first"><span>A</span></div>
+        <div aria-label="Row"><span>B</span></div>
+      </main>`,
+    );
+    expect(getSelector(doc.querySelector("#first")!)).toBe("#first");
+    expectResolvable(doc, doc.querySelectorAll("span"));
+  });
+
+  it("still indexes same-tag siblings that carry no anchor attribute", () => {
+    const doc = makeDoc(`<main><p>one</p><p>two</p></main>`);
+    expect(getSelector(doc.querySelectorAll("p")[1])).toContain("p:nth-of-type(2)");
+  });
+});

--- a/core/src/rules/utils/selector.ts
+++ b/core/src/rules/utils/selector.ts
@@ -46,30 +46,83 @@ export function extractAnchor(el: Element): string | null {
   return null;
 }
 
-/** Build a CSS segment for one element using stable attributes when available. */
-function buildSegment(el: Element): string {
+/** 1-based `:nth-of-type()` index of `el`, or null when it is the only one of its tag. */
+function nthOfTypeIndex(el: Element): number | null {
+  const parent = el.parentElement;
+  if (!parent) return null;
+  let count = 0;
+  let index = 0;
+  for (let i = 0; i < parent.children.length; i++) {
+    if (parent.children[i].tagName === el.tagName) {
+      count++;
+      if (parent.children[i] === el) index = count;
+    }
+  }
+  return count > 1 ? index : null;
+}
+
+/**
+ * Build a CSS segment for one element using stable attributes when available.
+ * `positional` also pins an anchor-attribute segment to its `:nth-of-type()`
+ * index, for the second pass over elements whose siblings share the value.
+ */
+function buildSegment(el: Element, positional: boolean): string {
   const tag = el.tagName.toLowerCase();
   for (const attr of ANCHOR_ATTRS) {
     const val = el.getAttribute(attr);
     if (val != null && val.length > 0 && val.length < 100) {
-      return `${tag}[${attr}="${escapeAttrVal(val)}"]`;
+      const segment = `${tag}[${attr}="${escapeAttrVal(val)}"]`;
+      const index = positional ? nthOfTypeIndex(el) : null;
+      return index === null ? segment : `${segment}:nth-of-type(${index})`;
     }
   }
-  const parent = el.parentElement;
-  if (parent) {
-    let count = 0;
-    let index = 0;
-    for (let i = 0; i < parent.children.length; i++) {
-      if (parent.children[i].tagName === el.tagName) {
-        count++;
-        if (parent.children[i] === el) index = count;
-      }
-    }
-    if (count > 1) {
-      return `${tag}:nth-of-type(${index})`;
-    }
+  const index = nthOfTypeIndex(el);
+  return index === null ? tag : `${tag}:nth-of-type(${index})`;
+}
+
+function resolvesTo(root: Document | ShadowRoot, selector: string, el: Element): boolean {
+  try {
+    const matches = root.querySelectorAll(selector);
+    return matches.length === 1 && matches[0] === el;
+  } catch {
+    return false; // invalid selector
   }
-  return tag;
+}
+
+/**
+ * Walk from `el` up to `docEl` accumulating segments, stopping as soon as the
+ * accumulated path resolves to `el` alone. `unique` reports whether it does —
+ * a path that reaches the top still ambiguous comes back false.
+ */
+function buildPath(
+  el: Element,
+  root: Document | ShadowRoot,
+  docEl: Element | null,
+  positional: boolean,
+): { selector: string; unique: boolean } {
+  const parts: string[] = [];
+  let current: Element | null = el;
+
+  while (current && current !== docEl) {
+    // Anchor to nearest ancestor with a stable ID
+    if (current !== el && isStableId(current.id)) {
+      parts.unshift(`#${CSS.escape(current.id)}`);
+      break;
+    }
+
+    parts.unshift(buildSegment(current, positional));
+
+    // Stop early when the selector already uniquely identifies the target
+    if (parts.length >= 2) {
+      const candidate = parts.join(" > ");
+      if (resolvesTo(root, candidate, el)) return { selector: candidate, unique: true };
+    }
+
+    current = current.parentElement;
+  }
+
+  const selector = parts.join(" > ");
+  return { selector, unique: resolvesTo(root, selector, el) };
 }
 
 /** Build a selector within a single root (document or shadow root). */
@@ -82,33 +135,14 @@ function buildSelectorWithinRoot(el: Element): string {
   // The document element itself — just use its tag name (unique by definition)
   if (el === docEl) return el.tagName.toLowerCase();
 
-  const parts: string[] = [];
-  let current: Element | null = el;
+  const attrPath = buildPath(el, root, docEl, false);
+  if (attrPath.unique) return attrPath.selector;
 
-  while (current && current !== docEl) {
-    // Anchor to nearest ancestor with a stable ID
-    if (current !== el && isStableId(current.id)) {
-      parts.unshift(`#${CSS.escape(current.id)}`);
-      break;
-    }
-
-    parts.unshift(buildSegment(current));
-
-    // Stop early when the selector already uniquely identifies the target
-    if (parts.length >= 2) {
-      const candidate = parts.join(" > ");
-      try {
-        const matches = root.querySelectorAll(candidate);
-        if (matches.length === 1 && matches[0] === el) return candidate;
-      } catch {
-        /* invalid selector, keep building */
-      }
-    }
-
-    current = current.parentElement;
-  }
-
-  return parts.join(" > ");
+  // Siblings share an anchor value (a radio group's `name`, repeated
+  // `aria-label`s), so the attribute path names more than one element. Retry
+  // pinning those segments positionally. Only paths that were already broken
+  // reach here, which keeps stable paths off the brittle positional form.
+  return buildPath(el, root, docEl, true).selector;
 }
 
 /**


### PR DESCRIPTION
Closes #33.

`buildSegment()` preferred `ANCHOR_ATTRS` and returned `tag[attr="val"]` without ever combining it with `:nth-of-type()`. Same-tag siblings sharing that value collapse to one segment, and `buildSelectorWithinRoot()` returned the joined path even when it never became unique — so `document.querySelector(violation.selector)` resolved to the wrong node. The common real-world shape is a radio group: every sibling `<input name="color">` becomes `input[name="color"]`.

## Approach

Two passes instead of one:

1. Build the attribute-preferring path exactly as before, and check whether it resolves to the element.
2. Only if it doesn't, rebuild with `:nth-of-type()` also pinned onto anchor-attribute segments.

Tightening unconditionally would be simpler but worse. Two `<div aria-label="Menu">` wrappers, one containing `<a href="/a">` and the other `<a href="/b">`, already produce the unique `div[aria-label="Menu"] > a[href="/a"]`. Pinning the ancestor anyway rewrites it to `div[aria-label="Menu"]:nth-of-type(1) > a[href="/a"]`, which then breaks whenever a menu is inserted above it — a stable attribute path traded for a brittle positional one, for no gain.

Mechanically: `buildSegment` takes a `positional` flag, the index computation is extracted to `nthOfTypeIndex()`, the walk moves into `buildPath()` returning `{selector, unique}`, and the uniqueness test becomes a shared `resolvesTo()` helper (it was already inline in the loop's early exit).

## Churn

Violation selectors feed snapshot identity, so this matters. It lands smaller than it looks:

- The snapshot key is not the CSS selector. `SnapshotViolation.selector` comes from `stableSelector()` (`matchers-internal/src/audit.ts:240`), which returns `getResilientLocator(el)` — testid, then role+name, then leaf text. It falls through to `getSelector()` only for elements with no testid, a skipped role (`generic`/`presentation`/`none`), and no short leaf text.
- For the ones that do fall through, the heal tiers absorb the change: T1 exact fails, then `anchor`/`role`/`htmlFingerprint`/`relativeLocation` match and rewrite the baseline rather than reporting fixed + new.

Measured rather than assumed — old vs new `getSelector()` output across 560 fixture pages (535 ACT + 25 mcp bench) plus a synthetic page with a radio group, duplicate nav links, and a repeated `aria-label` card grid, 3,353 elements total:

| | |
|---|---|
| selectors changed | 8 |
| of those, ambiguous beforehand | 8 |
| previously-unique selectors changed | 0 |
| ambiguous before → after | 8 → 0 |

The real fixture corpus changed nothing; all 8 came from the synthetic page. The duplicate `<a href="/docs">` links there were *not* rewritten — their `li:nth-of-type` ancestors already disambiguated them.

The invariant — no selector that previously resolved uniquely changes — is guarded by two of the new tests.

## Out of scope

`nthOfTypeIndex` uses `parentElement`, so elements that are direct children of a shadow root still get no index. That gap predates this change, and closing it means betting on how browsers scope `:nth-of-type` to shadow-root children; better as its own issue than a guess folded in here.

## Verification

- `bun run --filter=@accesslint/core test` — 986 pass
- `npx turbo run build typecheck test` — 39/39 tasks, including `matchers-internal`, `heal-diff`, and the 72 playwright snapshot/healing tests
- `npx turbo run act --filter=@accesslint/core` — conformance gate passed
- prettier + eslint clean on both touched files
