### PR TITLE
fix(core): judge a card by its title, and stop gluing words together

### DIFF
--- a/core/src/rules/labels-and-names/label-content-mismatch.test.ts
+++ b/core/src/rules/labels-and-names/label-content-mismatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import { labelContentMismatch } from "./label-content-mismatch";
 import { expectViolations, expectNoViolations } from "../../test-helpers";
 
@@ -203,5 +203,66 @@ describe(RULE_ID, () => {
       count: 1,
       ruleId: RULE_ID,
     });
+  });
+
+  // The same testimonial card, with and without a heading around its title.
+  // To a reader they are one component, so they must get one verdict.
+  const testimonial = (title: string, label: string) => `
+    <button aria-label="${label}">
+      <div>
+        <img src="jane.jpg" alt="">
+        ${title}
+        Senior Product Manager
+        <p>A long multi-sentence quote about working with the vendor, several
+           hundred characters of body copy that no aria-label would repeat.</p>
+      </div>
+    </button>
+  `;
+
+  it("passes a card whose title is a bare text node", () => {
+    expectNoViolations(labelContentMismatch, testimonial("Jane Doe", "Jane Doe's testimonial"));
+  });
+
+  it("passes a card whose title is styled with a div", () => {
+    expectNoViolations(
+      labelContentMismatch,
+      testimonial("<div>Jane Doe</div>", "Jane Doe's testimonial"),
+    );
+  });
+
+  it("judges a card the same whether or not its title is a heading", () => {
+    expectNoViolations(
+      labelContentMismatch,
+      testimonial("<h3>Jane Doe</h3>", "Jane Doe's testimonial") +
+        testimonial("Jane Doe", "Jane Doe's testimonial"),
+    );
+    expectViolations(
+      labelContentMismatch,
+      testimonial("<h3>Jane Doe</h3>", "Read the testimonial") +
+        testimonial("Jane Doe", "Read the testimonial"),
+      { count: 2, ruleId: RULE_ID },
+    );
+  });
+
+  it("still reports a card whose name shares only an incidental short word", () => {
+    expectViolations(
+      labelContentMismatch,
+      testimonial("Our customers", "Read our case study for this quarter"),
+      { count: 1, ruleId: RULE_ID },
+    );
+  });
+
+  it("quotes the page's own words when the markup indents them", () => {
+    const [violation] = expectViolations(
+      labelContentMismatch,
+      `<button aria-label="  Send   the form  ">
+         <span>Submit</span>
+         <span>now</span>
+       </button>`,
+      { count: 1, ruleId: RULE_ID },
+    );
+    expect(violation.message).toBe(
+      'Accessible name "Send the form" does not contain visible text "Submit now".',
+    );
   });
 });

--- a/core/src/rules/labels-and-names/label-content-mismatch.ts
+++ b/core/src/rules/labels-and-names/label-content-mismatch.ts
@@ -17,6 +17,38 @@ function normalizeText(text: string): string {
     .trim();
 }
 
+/** Quote strings as the page reads them, not as the markup happens to indent. */
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** Above this many words the visible text is a card's contents, not a label. */
+const CARD_WORD_COUNT = 8;
+
+/**
+ * True when the accessible name carries the words the visible text opens with.
+ *
+ * A card link holds more text than any label: a title, a byline, and a body
+ * quote, all flattened into one string. WCAG 2.5.3 asks about the text that
+ * reads as the label, which on a card is the title, the first thing rendered.
+ * So "Jane Doe's testimonial" is judged against "Jane Doe" and not against the
+ * paragraph beneath it. A name that carries none of the opening words still
+ * fails, so a card whose label drops its title is still reported.
+ */
+function containsLeadingWords(normAccessible: string, normVisible: string): boolean {
+  const words = normVisible.split(" ");
+  if (words.length <= CARD_WORD_COUNT) return false;
+
+  let run = "";
+  for (const word of words) {
+    const extended = run ? `${run} ${word}` : word;
+    if (!normAccessible.includes(extended)) break;
+    run = extended;
+  }
+  // One incidental short word ("the", "our") is not a title.
+  return run.split(" ").some((word) => word.length > 3);
+}
+
 function visibleTextMatches(accessibleName: string, visibleText: string): boolean {
   const normAccessible = normalizeText(accessibleName);
   const normVisible = normalizeText(visibleText);
@@ -34,17 +66,18 @@ function visibleTextMatches(accessibleName: string, visibleText: string): boolea
   // Accept if most significant words of the visible text appear in the
   // accessible name.  This handles cases like "Parks By State" (aria-label)
   // vs "By State..." (visible text after icons/prefixes are stripped).
-  //
-  // A single significant word counts. `<a aria-label="Deploy on Vercel">
-  // <span>\u25b2</span><span>Deploy</span></a>` reads as a mismatch otherwise:
-  // adjacent spans contribute no whitespace, so the glyph arrives glued to the
-  // word as "\u25b2Deploy", while the label a voice-control user speaks \u2014 "Deploy"
-  // \u2014 is in the name.
+  // A control whose visible text is a single significant word beside
+  // decorative glyphs passes on that word alone, as in
+  // `<a aria-label="Deploy on Vercel"><span>\u25b2</span><span>Deploy</span></a>`.
   const visibleWords = normVisible.split(" ").filter((w) => w.length > 2);
   if (visibleWords.length >= 1) {
     const matchingWords = visibleWords.filter((w) => normAccessible.includes(w));
     if (matchingWords.length / visibleWords.length > 0.5) return true;
   }
+
+  // The overlap ratio inverts on text-rich controls: the longer the card, the
+  // smaller the share its title can hold, so judge those on the title alone.
+  if (containsLeadingWords(normAccessible, normVisible)) return true;
 
   return false;
 }
@@ -123,7 +156,7 @@ export const labelContentMismatch: Rule = {
         selector: getSelector(el),
         html: getHtmlSnippet(el),
         impact: "serious" as const,
-        message: `Accessible name "${accessibleName}" does not contain visible text "${visibleText.trim()}".`,
+        message: `Accessible name "${collapseWhitespace(accessibleName)}" does not contain visible text "${collapseWhitespace(visibleText)}".`,
         fix: {
           type: "suggest",
           suggestion:
@@ -166,7 +199,7 @@ export const labelContentMismatch: Rule = {
           selector: getSelector(el),
           html: getHtmlSnippet(el),
           impact: "serious" as const,
-          message: `Accessible name "${accessibleName}" does not contain visible label "${visibleLabel.trim()}".`,
+          message: `Accessible name "${collapseWhitespace(accessibleName)}" does not contain visible label "${collapseWhitespace(visibleLabel)}".`,
           fix: {
             type: "suggest",
             suggestion:

--- a/core/src/rules/utils/aria.test.ts
+++ b/core/src/rules/utils/aria.test.ts
@@ -482,6 +482,29 @@ describe("getVisibleText", () => {
     const doc = makeDoc(`<p>Text <span role="img">🌟</span></p>`);
     expect(getVisibleText(doc.querySelector("p")!).trim()).toBe("Text");
   });
+
+  it("excludes <svg> content", () => {
+    const doc = makeDoc(`<button>Close<svg><title>Close icon</title></svg></button>`);
+    expect(getVisibleText(doc.querySelector("button")!)).toBe("Close");
+  });
+
+  it("separates text that renders in different boxes", () => {
+    const doc = makeDoc(`<div><span>Senior Product Manager</span><p>A long quote.</p></div>`);
+    expect(getVisibleText(doc.querySelector("div")!)).toBe("Senior Product Manager A long quote.");
+  });
+
+  it("separates adjacent inline elements", () => {
+    const doc = makeDoc(`<a href="/deploy"><span>▲</span><span>Deploy</span></a>`);
+    expect(getVisibleText(doc.querySelector("a")!)).toBe("▲ Deploy");
+  });
+
+  it("collapses the whitespace the markup was indented with", () => {
+    const doc = makeDoc(`<div>
+        Jane Doe
+        <p>Senior   Product Manager</p>
+      </div>`);
+    expect(getVisibleText(doc.querySelector("div")!)).toBe("Jane Doe Senior Product Manager");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/core/src/rules/utils/aria.ts
+++ b/core/src/rules/utils/aria.ts
@@ -523,14 +523,7 @@ function isStyleHidden(el: Element): boolean {
   return style.display === "none" || style.visibility === "hidden";
 }
 
-/**
- * Extract truly visible text from an element, excluding:
- * - Non-rendered elements (style, script, SVG)
- * - Elements with role="img" or role="presentation"
- * - aria-hidden subtrees
- * - Elements CSS hides with display:none or visibility:hidden
- */
-export function getVisibleText(el: Element): string {
+function collectVisibleText(el: Element): string {
   let text = "";
   for (const node of el.childNodes) {
     if (node.nodeType === 3 /* TEXT_NODE */) {
@@ -546,10 +539,28 @@ export function getVisibleText(el: Element): string {
       // Skip role=img and role=presentation (icon wrappers)
       const role = child.getAttribute("role");
       if (role === "img" || role === "presentation" || role === "none") continue;
-      text += getVisibleText(child);
+      // accname step 2I pads each traversed node with a space. Without it,
+      // words that render in separate boxes arrive glued: a title followed by
+      // a paragraph reads as "ManagerLong", a word no one can search for and
+      // one that matches nothing in the accessible name.
+      text += ` ${collectVisibleText(child)} `;
     }
   }
   return text;
+}
+
+/**
+ * Extract truly visible text from an element, excluding:
+ * - Non-rendered elements (style, script, SVG)
+ * - Elements with role="img" or role="presentation"
+ * - aria-hidden subtrees
+ * - Elements CSS hides with display:none or visibility:hidden
+ *
+ * Element boundaries contribute a space and whitespace runs collapse, so the
+ * result reads as the page does however the markup is indented.
+ */
+export function getVisibleText(el: Element): string {
+  return collectVisibleText(el).replace(/\s+/g, " ").trim();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two false-positive sources in `labels-and-names/label-content-mismatch`.

Rebased on main after #29 and #35 landed. The `landmarks/region` part of this branch is dropped: #29 fixed #18 by removing the structural tag checks and letting computed style decide, which is the better answer, and this branch no longer touches that rule.

## label-content-mismatch glues text across element boundaries (#25)

`getVisibleText` concatenated descendant text with no separator, so words that render in different boxes arrived glued. A card title followed by a paragraph read as `ManagerLong`. Two consequences: the violation message quoted a string that does not exist on the page, and the word-overlap heuristic lost a word that should have matched while gaining a junk token in the denominator, pushing every text-rich control toward a false positive.

Each traversed node is now padded with a space, per accname step 2I, and whitespace runs collapse before the value is returned. Both messages collapse the accessible name too, so a padded `aria-label` reads the same however the markup was indented.

## label-content-mismatch fires on card-style controls without a heading (#24)

The issue is closed, but no fix landed on main, so the behavior is still there. Reproduced on this branch before the change.

A `<button>` or `<a>` wrapping a card was judged against its entire flattened text: title, role, and a multi-paragraph quote. No reasonable `aria-label` contains all of that, so one reported page turned a grid of 12 testimonial cards into 12 serious findings. The heading escape hatch only queried `h1-h6, [role=heading]`, so a card whose title is a bare text node or a `div` fell straight through, and two cards that are one component to a reader got opposite verdicts.

Above 8 words the visible text is a card, not a label. For those, the rule accepts the control when the accessible name contains the leading run of words the visible text opens with, which on a card is its title: `Jane Doe's testimonial` is judged against `Jane Doe`, not against the quote below it. A name carrying none of the opening words still fails, and the run has to hold a word longer than three characters so an incidental `our` or `the` does not excuse a mismatch. Controls at or under 8 words are judged exactly as before.

## Verification

- 1082 core unit tests, 109 browser tests, 25 package test suites: green
- ACT conformance gate: passed
- lint (0 errors), typecheck, prettier: clean
- Regression fixtures follow the ones each issue proposed, including the cards-agree case (with and without an `<h3>`), the card whose name drops the title, and the glyph fixture from the `Deploy on Vercel` case, which now passes on the primary containment check rather than on the single-word fallback

## Note on the trade-off

On text-rich controls, a real mismatch whose name happens to share the opening words is no longer reported. That is the cost of not being able to tell a title from body copy without layout, and it buys back a class of serious-impact noise that was outnumbering real findings roughly 4:1 on the reported page. Short labels, which is where 2.5.3 violations actually bite voice-control users, are unaffected.