### PR TITLE
revert(core): drop the leading-run hatch for card-style controls

### DIFF
--- a/core/src/rules/labels-and-names/label-content-mismatch.test.ts
+++ b/core/src/rules/labels-and-names/label-content-mismatch.test.ts
@@ -205,53 +205,6 @@ describe(RULE_ID, () => {
     });
   });
 
-  // The same testimonial card, with and without a heading around its title.
-  // To a reader they are one component, so they must get one verdict.
-  const testimonial = (title: string, label: string) => `
-    <button aria-label="${label}">
-      <div>
-        <img src="jane.jpg" alt="">
-        ${title}
-        Senior Product Manager
-        <p>A long multi-sentence quote about working with the vendor, several
-           hundred characters of body copy that no aria-label would repeat.</p>
-      </div>
-    </button>
-  `;
-
-  it("passes a card whose title is a bare text node", () => {
-    expectNoViolations(labelContentMismatch, testimonial("Jane Doe", "Jane Doe's testimonial"));
-  });
-
-  it("passes a card whose title is styled with a div", () => {
-    expectNoViolations(
-      labelContentMismatch,
-      testimonial("<div>Jane Doe</div>", "Jane Doe's testimonial"),
-    );
-  });
-
-  it("judges a card the same whether or not its title is a heading", () => {
-    expectNoViolations(
-      labelContentMismatch,
-      testimonial("<h3>Jane Doe</h3>", "Jane Doe's testimonial") +
-        testimonial("Jane Doe", "Jane Doe's testimonial"),
-    );
-    expectViolations(
-      labelContentMismatch,
-      testimonial("<h3>Jane Doe</h3>", "Read the testimonial") +
-        testimonial("Jane Doe", "Read the testimonial"),
-      { count: 2, ruleId: RULE_ID },
-    );
-  });
-
-  it("still reports a card whose name shares only an incidental short word", () => {
-    expectViolations(
-      labelContentMismatch,
-      testimonial("Our customers", "Read our case study for this quarter"),
-      { count: 1, ruleId: RULE_ID },
-    );
-  });
-
   it("quotes the page's own words when the markup indents them", () => {
     const [violation] = expectViolations(
       labelContentMismatch,

--- a/core/src/rules/labels-and-names/label-content-mismatch.ts
+++ b/core/src/rules/labels-and-names/label-content-mismatch.ts
@@ -22,33 +22,6 @@ function collapseWhitespace(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
-/** Above this many words the visible text is a card's contents, not a label. */
-const CARD_WORD_COUNT = 8;
-
-/**
- * True when the accessible name carries the words the visible text opens with.
- *
- * A card link holds more text than any label: a title, a byline, and a body
- * quote, all flattened into one string. WCAG 2.5.3 asks about the text that
- * reads as the label, which on a card is the title, the first thing rendered.
- * So "Jane Doe's testimonial" is judged against "Jane Doe" and not against the
- * paragraph beneath it. A name that carries none of the opening words still
- * fails, so a card whose label drops its title is still reported.
- */
-function containsLeadingWords(normAccessible: string, normVisible: string): boolean {
-  const words = normVisible.split(" ");
-  if (words.length <= CARD_WORD_COUNT) return false;
-
-  let run = "";
-  for (const word of words) {
-    const extended = run ? `${run} ${word}` : word;
-    if (!normAccessible.includes(extended)) break;
-    run = extended;
-  }
-  // One incidental short word ("the", "our") is not a title.
-  return run.split(" ").some((word) => word.length > 3);
-}
-
 function visibleTextMatches(accessibleName: string, visibleText: string): boolean {
   const normAccessible = normalizeText(accessibleName);
   const normVisible = normalizeText(visibleText);
@@ -74,10 +47,6 @@ function visibleTextMatches(accessibleName: string, visibleText: string): boolea
     const matchingWords = visibleWords.filter((w) => normAccessible.includes(w));
     if (matchingWords.length / visibleWords.length > 0.5) return true;
   }
-
-  // The overlap ratio inverts on text-rich controls: the longer the card, the
-  // smaller the share its title can hold, so judge those on the title alone.
-  if (containsLeadingWords(normAccessible, normVisible)) return true;
 
   return false;
 }


### PR DESCRIPTION
Backs out the card half of #36

#36 landed two things. This reverts one of them.

**Removed:** the leading-run acceptance in `label-content-mismatch`. Above 8 words of visible text, the rule treated the control as a card and passed it when the accessible name contained the run of words the visible text opens with. Card-style controls whose title is not a heading are reported again, as they were before #36.

**Kept:** the `getVisibleText` fix (issue #25). Element boundaries contribute a space and whitespace runs collapse, so a card title followed by a paragraph no longer reads as `ManagerLong`. Both violation messages still collapse the accessible name. That fix stands on its own and is unrelated to the card judgment.

**Untouched:** the heading escape hatch from 92d9c29, which predates this work.

Issue #24 stays closed. The false positive it describes is present again, so reopen it if you want the noise tracked.

## Verification

- 1078 core unit tests: green (4 fewer than main, the card fixtures this removes)
- lint (0 errors), typecheck, prettier: clean