### PR TITLE
Don't judge a label a user cannot see

### DIFF
--- a/core/src/integration/label-content-mismatch.browser.test.ts
+++ b/core/src/integration/label-content-mismatch.browser.test.ts
@@ -49,6 +49,70 @@ describe("visible text under a real cascade", () => {
     expect(violations[0].ruleId).toBe("labels-and-names/label-content-mismatch");
   });
 
+  it("passes: a card link in a class-hidden carousel slide", () => {
+    setContent(`
+      <style>.slide { display: none } .slide.current { display: block }</style>
+      <div class="carousel">
+        <div class="slide current">
+          <a href="/post-1" aria-label="The Shape of Quiet Rivers">
+            <h3>The Shape of Quiet Rivers</h3>
+          </a>
+        </div>
+        <div class="slide">
+          <a href="/post-2" aria-label="Read more">
+            <h3>A Longer Way Around</h3>
+            <p>Body prose that nobody on this page can see.</p>
+          </a>
+        </div>
+      </div>
+    `);
+    expect(run()).toHaveLength(0);
+  });
+
+  it("still reports the on-screen slide when a hidden sibling would also mismatch", () => {
+    setContent(`
+      <style>.slide { display: none } .slide.current { display: block }</style>
+      <div class="carousel">
+        <div class="slide current">
+          <a href="/post-1" aria-label="Read more">
+            <h3>The Shape of Quiet Rivers</h3>
+            <p>Body prose that is on screen.</p>
+          </a>
+        </div>
+        <div class="slide">
+          <a href="/post-2" aria-label="Read more">
+            <h3>A Longer Way Around</h3>
+            <p>Body prose that nobody can see.</p>
+          </a>
+        </div>
+      </div>
+    `);
+    const violations = run();
+    expect(violations).toHaveLength(1);
+    expect(violations[0].selector).toContain("/post-1");
+  });
+
+  it("passes: a control under a visibility:hidden ancestor", () => {
+    setContent(`
+      <style>.offstage { visibility: hidden }</style>
+      <div class="offstage">
+        <button aria-label="Send email">Submit</button>
+      </div>
+    `);
+    expect(run()).toHaveLength(0);
+  });
+
+  it("passes: a labelled field in a class-hidden step of a form", () => {
+    setContent(`
+      <style>.step { display: none }</style>
+      <div class="step">
+        <label for="ship">Shipping address</label>
+        <input id="ship" aria-label="Billing address">
+      </div>
+    `);
+    expect(run()).toHaveLength(0);
+  });
+
   it("passes: a card link whose name is its title plus a stray comma", () => {
     setContent(`
       <style>.tags span { display: inline-block }</style>

--- a/core/src/rules/labels-and-names/label-content-mismatch.ts
+++ b/core/src/rules/labels-and-names/label-content-mismatch.ts
@@ -1,6 +1,6 @@
 import type { Rule } from "../types";
 import { getSelector, getHtmlSnippet } from "../utils/selector";
-import { getAccessibleName, isAriaHidden, getVisibleText } from "../utils/aria";
+import { getAccessibleName, isAriaHidden, isComputedHidden, getVisibleText } from "../utils/aria";
 
 // ACT rule 2ee8b8's label-in-name algorithm: case fold, apply compatibility
 // normalization, then replace every character that is not a letter or a digit
@@ -87,6 +87,7 @@ export const labelContentMismatch: Rule = {
       'button, [role="button"], a[href], input[type="submit"], input[type="button"]',
     )) {
       if (isAriaHidden(el)) continue;
+      if (isComputedHidden(el)) continue;
 
       const accessibleName = getAccessibleName(el);
       if (!accessibleName) continue; // No name - different violation
@@ -137,6 +138,7 @@ export const labelContentMismatch: Rule = {
     // Check labeled form fields
     for (const el of doc.querySelectorAll("input, select, textarea")) {
       if (isAriaHidden(el)) continue;
+      if (isComputedHidden(el)) continue;
       if (
         el instanceof HTMLInputElement &&
         ["hidden", "submit", "button", "image"].includes(el.type)


### PR DESCRIPTION
`labels-and-names/label-content-mismatch` gated only on `isAriaHidden`, which reads inline `style` and the `hidden` attribute. Pages hide things with a class far more often than inline: a carousel slide, an inactive tab panel, a collapsed form step. The rule walked into those subtrees, read text nobody can see, and reported a mismatch on a control that is not on the page.

## The fix

Gate on `isComputedHidden` as well, in both the control loop and the form-field loop. That is the same two-line pairing `button-name.ts` and `link-name.ts` already use, so this brings the rule in line with its neighbours rather than inventing a mechanism.

`isComputedHidden` walks ancestors and asks each one for its computed style. The ancestor walk is the load-bearing part: `getComputedStyle` on a child of a `display:none` element reports that child's *own* specified display, so a per-node check never sees the hiding.

## Why this was missed before

0.19.0 shipped "skip content in `display:none` subtrees", which corrected `focus-order`, `landmarks/region` and `heading-order`. It never reached this rule. I confirmed that by A/B-ing the published 0.18.0 and 0.20.0 IIFE bundles in one chromium against the same page — both flagged a card link inside a class-hidden div, same rule, same selector.

## Tests

New cases live in the **browser** project, not the unit suite. The unit suite parses markup with no cascade, so it cannot express a class-hidden subtree at all — a unit test here would pass without proving anything.

- a card link in a class-hidden carousel slide → no violation
- a hidden slide next to a visible one → still exactly one violation, on the visible slide (guards against over-suppressing)
- a control under a `visibility: hidden` ancestor → no violation
- a labelled field in a class-hidden form step → covers the second loop

All four fail on `main` and pass with the fix.

## Verification

- unit: 1078 passed
- browser: 113 passed
- lint: 0 errors; typecheck clean
- ACT conformance gate: **PASSED** — but note it does **not** cover this rule. `label-content-mismatch` declares `actRuleIds: ["2ee8b8"]`, yet 2ee8b8 has no entry in `src/act/act-mapping.ts`, so no ACT fixtures run against it. The gate here only shows the change breaks nothing else.
- End-to-end against a built IIFE: the false positive disappears and no other finding on the probe page changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)